### PR TITLE
Fix to Browser.upgradeCrosswalk

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -483,7 +483,7 @@ Browser.clean = function clean(appDirectory) {
 
 Browser.upgradeCrosswalk = function upgradeCrosswalk(appDirectory) {
   events.emit('log', 'Updating your Ionic project with the latest build of Crosswalk'.green);
-  Browser.clean();
+  Browser.clean(appDirectory);
   Browser.installCrosswalk(appDirectory, Browser.defaultCrosswalkVersion);
 };
 


### PR DESCRIPTION
Fix for Browser.upgradeCrosswalk;  it was trying to call Browser.clean
without the required appDirectory param