### PR TITLE
cordovaPlatforms in package.json may have a duplicated platform entry

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -317,7 +317,7 @@ State.addOrUpdatePlatformToPackageJson = function addOrUpdatePlatformToPackageJs
       existingPlatform = packageJson.cordovaPlatforms[i];
       existingPlatformIndex = i;
       break;
-    } else if (packageJson.cordovaPlatforms[i].id == platformId) {
+    } else if (packageJson.cordovaPlatforms[i].platform == platformId) {
       existingPlatform = packageJson.cordovaPlatforms[i];
       existingPlatform.locator = platformInfo.locator;
       existingPlatformIndex = i;

--- a/spec/state.spec.js
+++ b/spec/state.spec.js
@@ -96,7 +96,16 @@ describe('State', function() {
       var platformInfo = { platform: 'android', locator: fileLocator };
 
       State.addOrUpdatePlatformToPackageJson(defaultPackageJson, 'android', platformInfo);
-      expect(defaultPackageJson).toBe(defaultPackageJson);
+      expect(defaultPackageJson).toEqual(afterPackageJson);
+    });
+
+    it('should overwrite ios version when ios and version are added', function() {
+      defaultPackageJson = { cordovaPlatforms: [{platform: 'ios', locator: 'ios@3.7.0', version: '3.7.0'}], cordovaPlugins: [] };
+      var afterPackageJson = { cordovaPlatforms: [{platform: 'ios', locator: 'ios@3.8.0', version: '3.8.0'}], cordovaPlugins: [] };
+      var platformInfo = { platform: 'ios', locator: 'ios@3.8.0', version: '3.8.0' };
+
+      State.addOrUpdatePlatformToPackageJson(defaultPackageJson, 'ios', platformInfo);
+      expect(defaultPackageJson).toEqual(afterPackageJson);
     });
   });
 


### PR DESCRIPTION
cordovaPlatforms in package.json may have a duplicated platform entry such as:

```json
  "cordovaPlatforms": [
    {
      "platform": "ios",
      "version": "3.7.0",
      "locator": "ios@3.7.0"
    },
    {
      "platform": "ios",
      "version": "3.8.0",
      "locator": "ios@3.8.0"
    }
  ],
```

## Reproduce

1. install platform with version ( ``ionic platform add ios@3.7.0`` )
1. remove platform directory **manually** ( ``rm -rf platforms/ios`` )
1. install platform with version again ( ``ionic platform add ios@3.8.0`` )

Then, platform is collectly installed, but package.json is not updated but added.