### PR TITLE
use CONNECT_LIVE_RELOAD_PORT environment variable if available

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -295,8 +295,14 @@ Serve.runLivereload = function runLivereload(options, app) {
       }
     });
 
+    //check if CONNECT_LIVE_RELOAD_PORT is defined and use that instead
+    var connectLiveReloadPort = options.liveReloadPort;
+    if(process.env.CONNECT_LIVE_RELOAD_PORT){
+        connectLiveReloadPort = process.env.EXTERNAL_LIVE_RELOAD_PORT;
+    }
+
     app.use(require('connect-livereload')({
-      port: options.liveReloadPort
+      port: connectLiveReloadPort
     }));
 
   } catch (ex) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -298,7 +298,7 @@ Serve.runLivereload = function runLivereload(options, app) {
     //check if CONNECT_LIVE_RELOAD_PORT is defined and use that instead
     var connectLiveReloadPort = options.liveReloadPort;
     if(process.env.CONNECT_LIVE_RELOAD_PORT){
-        connectLiveReloadPort = process.env.EXTERNAL_LIVE_RELOAD_PORT;
+        connectLiveReloadPort = process.env.CONNECT_LIVE_RELOAD_PORT;
     }
 
     app.use(require('connect-livereload')({


### PR DESCRIPTION
useful for docker runtime environments where the livereload server is running on port A but is exposed by docker on port B