### PR TITLE
add bower packages for starters

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -537,6 +537,11 @@ Start.initCordova = function(options, appSetup) {
            cmds.push('ionic plugin add ' + appSetup.plugins[x]);
          }
 
+      // add bower packages
+         for(var y = 0; y < appSetup.bower.length; y++) {
+           cmds.push('bower install ' + appSetup.bower[y]);
+         }
+
          // platform add android with --android flag
          if(options.android) {
            cmds.push('ionic platform add android');


### PR DESCRIPTION
adds the ability to add bower packages to a starter project.

Usage:

```json
{
  "plugins": [
    "cordova-plugin-device",
    "cordova-plugin-console",
    "com.ionic.keyboard",
    "cordova-plugin-inappbrowser"
  ],
  "bower":[
    "angularfire",
    "ngCordova"
  ],
  "sass": false
}

```