### PR TITLE
allow cordova browser as a platform

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -361,26 +361,21 @@ Serve.startServer = function startServer(options, app) {
 
       // platformWWW = appPlatformWWW;
 
-      if (options.isPlatformServe) {
-        fs.readFile( path.resolve(path.join(platformWWW, platformUrl)), function (err, buf) {
-          res.setHeader('Content-Type', 'application/javascript');
-          if (err) {
-            res.end('// mocked cordova.js response to prevent 404 errors during development');
-            if(req.url == '/cordova.js') {
-              Serve.serverLog(req, '(mocked)', options);
-            } else {
-              Serve.serverLog(req, '(Error ' + platformWWW + ')', options);
-            }
-          } else {
-            Serve.serverLog(req, '(' + platformWWW + ')', options);
-            res.end(buf);
-          }
-        });
-      } else {
-        Serve.serverLog(req, '(mocked)', options);
+      fs.readFile( path.resolve(path.join(platformWWW, platformUrl)), function (err, buf) {
         res.setHeader('Content-Type', 'application/javascript');
-        res.end('// mocked cordova.js response to prevent 404 errors during development');
-      }
+        if (err) {
+          res.end('// mocked cordova.js response to prevent 404 errors during development');
+          if(req.url == '/cordova.js') {
+            Serve.serverLog(req, '(mocked)', options);
+          } else {
+            Serve.serverLog(req, '(Error ' + platformWWW + ')', options);
+          }
+        } else {
+          Serve.serverLog(req, '(' + platformWWW + ')', options);
+          res.end(buf);
+        }
+      });
+
       return;
     }
 
@@ -650,6 +645,8 @@ function getPlatformWWW(req) {
 
     } else if(ua.indexOf('android') > -1) {
       platformPath = path.join('platforms', 'android', 'assets', 'www');
+    } else {
+      platformPath = path.join('platforms', 'browser', 'www');
     }
   }
 


### PR DESCRIPTION
cordova supports the browser as a platform now. 

This changes enable to serve cordova browser platform assets.
Maybe i miss somthing, but it will be nice if the browser shims are useable while developing in the browser. I think it would not break any existing code, since if you didn't installed the browser platform the current behaviour still persist.

Best Regards 

