### PR TITLE
Better handling of missing core

### DIFF
--- a/lib/io-config.js
+++ b/lib/io-config.js
@@ -215,19 +215,25 @@ IoConfig.writeIoConfig = function writeIoConfig(key, val, set) {
           } else {
             console.log('Building core config factory...')
           }
-          fs.readFile(CORE_FILE, function(er, content) {
-            var jsFile = String(content);
-            var slices = jsFile.split('// Auto-generated configuration factory');
-            if (slices.length === 3) {
-              jsFile = slices[0] + FACTORY_PREFIX + JSON.stringify(jsonObj) + FACTORY_SUFFIX + slices[2];
-              fs.writeFile(CORE_FILE, jsFile, function(e){
-                if (e) {
-                  deferred.reject(new Error(e));
+          IoConfig.isCoreAvailable().then(function(available) {
+            if (available) {
+              fs.readFile(CORE_FILE, function(er, content) {
+                var jsFile = String(content);
+                var slices = jsFile.split('// Auto-generated configuration factory');
+                if (slices.length === 3) {
+                  jsFile = slices[0] + FACTORY_PREFIX + JSON.stringify(jsonObj) + FACTORY_SUFFIX + slices[2];
+                  fs.writeFile(CORE_FILE, jsFile, function(e){
+                    if (e) {
+                      deferred.reject(new Error(e));
+                    }
+                    deferred.resolve(key);
+                  });
+                } else {
+                  console.log('Outdated ionic-service-core, please install the latest version.'.red);
+                  deferred.resolve(key);
                 }
-                deferred.resolve(key);
               });
             } else {
-              console.log('Outdated ionic-service-core, please install the latest version.'.red);
               deferred.resolve(key);
             }
           });
@@ -375,20 +381,16 @@ IoConfig.initIoPlatform = function initIoPlatform(appDirectory, jar) {
   try {
     return IoConfig.dashInit(project, jar).then(function(key){
       // Save App ID and API key to the io-config
-      IoConfig.isCoreAvailable().then(function(available) {
-        if (available) {
-          IoConfig.writeIoConfig('app_id', key.app_id, true).then(function(obj){
-            if (key.api_key) {
-              IoConfig.writeIoConfig('api_key', key.api_key, true).then(function(apiKey){
-                IoConfig.warnMissingData();
-              }, function(error) {
-                console.log('Error saving API key:', error);
-              });
-            }
+      IoConfig.writeIoConfig('app_id', key.app_id, true).then(function(obj){
+        if (key.api_key) {
+          IoConfig.writeIoConfig('api_key', key.api_key, true).then(function(apiKey){
+            IoConfig.warnMissingData();
           }, function(error) {
-            console.log('Error saving app ID:', error);
+            console.log('Error saving API key:', error);
           });
         }
+      }, function(error) {
+        console.log('Error saving app ID:', error);
       });
       // Set project vars
       project.set('app_id', key.app_id);

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -45,16 +45,11 @@ Upload.doUpload = function doUpload(appDirectory, jar, note, deploy) {
       uploadKey = key;
 
       // Save App ID and API key to the io-config
-      ioLib.isCoreAvailable()
-      .then(function(available) {
-        if (available) {
-          ioLib.writeIoConfig('app_id', key.app_id, true)
-          .then(function(key){
-            // Do nothing
-          }, function(error) {
-            console.log('Error saving app ID:', error);
-          });
-        }
+      ioLib.writeIoConfig('app_id', key.app_id, true)
+      .then(function(key){
+        // Do nothing
+      }, function(error) {
+        console.log('Error saving app ID:', error);
       });
 
       // Set project vars
@@ -70,16 +65,10 @@ Upload.doUpload = function doUpload(appDirectory, jar, note, deploy) {
       if (status && (typeof status === 'object') && status.version) {
         version = status.version;
         if (status.api_key) {
-          ioLib.isCoreAvailable()
-          .then(function(available) {
-            if (available) {
-              ioLib.writeIoConfig('api_key', status.api_key, true)
-              .then(function(apiKey){
-                ioLib.warnMissingData();
-              }, function(error) {
-                console.log('Error saving API key:', error);
-              });
-            }
+          ioLib.writeIoConfig('api_key', status.api_key, true).then(function(apiKey){
+            ioLib.warnMissingData();
+          }, function(error) {
+            console.log('Error saving API key:', error);
           });
         }
       }


### PR DESCRIPTION
When `ionic-service-core` is missing, it would fail to write to `.io-config.json`.  

This was bad.

It doesn't do this anymore, and instead writes the json but ignores core.