### PR TITLE
Add newline after JSON.stringify call when creating package.json

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -392,7 +392,7 @@ State.savePackageJson = function savePackageJson(appDirectory, packageJsonData) 
   events.emit('verbose', 'State.savePackageJson', appDirectory, packageJsonData);
   try {
     var packageJsonPath = path.join(appDirectory, 'package.json');
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonData, null, 2));
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonData, null, 2) + "\n");
   } catch (e) {
     events.emit('log', ('Error saving ' + packageJsonPath + ': ' + e).bold);
   }


### PR DESCRIPTION
As per this issue: https://github.com/driftyco/ionic-cli/issues/271

Non-binary files should end with \n, makes using version control like Git much easier. Adding packages will create a package.json without a newline, which is automatically added by git upon commit, but 'git status' will annoyingly display a difference.