### PR TITLE
added dependant startup tasks

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -20,7 +20,8 @@ var fs = require('fs'),
     Utils = require('./utils'),
     events = require('./events'),
     shelljs = require('shelljs'),
-    ports = require('./ports');
+    ports = require('./ports'),
+    crossSpawn = require('cross-spawn');
 
 var Serve = module.exports;
 
@@ -174,7 +175,8 @@ Serve.loadSettings = function loadSettings(argv, project) {
 
   options.watchSass = project.get('sass') === true && !argv.nosass && !argv.n;
   options.gulpStartupTasks = project.get('gulpStartupTasks');
-  
+  options.gulpDependantTasks = project.get('gulpDependantTasks');
+
   options.browser = argv.browser || argv.w || '';
   options.browserOption = argv.browserOption || argv.o || '';
 
@@ -247,6 +249,26 @@ Serve.checkForDocumentRoot = function checkForDocumentRoot(options) {
   return true;
 }
 
+Serve.gulpDependantTasks = function gulpDependantTasks(options) {
+  var deferred = Q.defer();
+  // gulpDependantTasks should be an array of tasks set in the project config
+  if (options.gulpDependantTasks && options.gulpDependantTasks.length) {
+    var tasks = options.gulpDependantTasks || [];
+
+    if(!Utils.gulpInstalledGlobally()) {
+      var message = ['You have specified Gulp start up tasks in your ionic.project file.'.red, '\n', 'However, you do not have Gulp installed globally. Please run '.red, '`npm install -g gulp`'.green].join('');
+      Utils.fail(message);
+      deferred.reject(message);
+    } else {
+      events.emit('log', 'Gulp dependant tasks:'.green.bold, tasks);
+      deferred.resolve(crossSpawn.sync('gulp', tasks, { stdio: 'inherit' }));
+    }
+  } else {
+    deferred.resolve();
+  }
+  return deferred.promise;
+}
+
 Serve.gulpStartupTasks = function gulpStartupTasks(options) {
   // gulpStartupTasks should be an array of tasks set in the project config
   // watchSass is for backwards compatible sass: true project config
@@ -259,13 +281,13 @@ Serve.gulpStartupTasks = function gulpStartupTasks(options) {
     }
 
     events.emit('log', 'Gulp startup tasks:'.green.bold, tasks);
-    return require('cross-spawn').spawn('gulp', tasks, { stdio: 'inherit' });
+    return crossSpawn.spawn('gulp', tasks, { stdio: 'inherit' });
   }
 }
 
 Serve.runLivereload = function runLivereload(options, app) {
   var q = Q.defer();
-  
+
   try {
 
     if (!options.runLivereload) {
@@ -493,14 +515,21 @@ Serve.start = function start(options) {
       return Q.reject('"' + options.documentRoot + '" directory cannot be found. Please make sure the working directory is an Ionic project.'); //It failed, do nothing
     }
 
-    if (!options.nogulp) {
-    //Gulp serve start tasks
-      options.childProcess = Serve.gulpStartupTasks(options);
-    }
-
-    var runliveReloadProcess = Serve.runLivereload(options, app);
-
-    return runliveReloadProcess
+    return Q.when()
+    .then(function() {
+      if (!options.nogulp) {
+        return Serve.gulpDependantTasks(options)
+      }
+    })
+    .then(function() {
+      if (!options.nogulp) {
+      //Gulp serve start tasks
+        options.childProcess = Serve.gulpStartupTasks(options);
+      }
+    })
+    .then(function() {
+      return Serve.runLivereload(options, app);
+    })
     .then(function(server) {
       events.emit('log', 'Running live reload server:'.green.bold, options.liveReloadServer );
       events.emit('log', 'Watching :'.green.bold, options.watchPatterns);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "connect": "3.1.1",
     "connect-livereload": "0.5.2",
     "crc": "3.2.1",
-    "cross-spawn": "0.2.3",
+    "cross-spawn": "2.0.0",
     "event-stream": "3.0.x",
     "finalhandler": "0.2.0",
     "form-data": "0.1.4",

--- a/spec/serve.spec.js
+++ b/spec/serve.spec.js
@@ -14,6 +14,7 @@ var defaultServeOptions = {
   defaultBrowser: undefined,
   documentRoot: 'www',
   gulpStartupTasks: undefined,
+  gulpDependantTasks: undefined,
   isAddressCmd: false,
   launchBrowser: true,
   launchLab: undefined,
@@ -40,6 +41,7 @@ function compareOptions(options) {
   expect(options.defaultBrowser).toBe(defaultServeOptions.defaultBrowser);
   expect(options.documentRoot).toBe(defaultServeOptions.documentRoot);
   expect(options.gulpStartupTasks).toBe(defaultServeOptions.gulpStartupTasks);
+  expect(options.gulpDependantTasks).toBe(defaultServeOptions.gulpDependantTasks);
   expect(options.isAddressCmd).toBe(defaultServeOptions.isAddressCmd);
   expect(options.launchBrowser).toBe(defaultServeOptions.launchBrowser);
   expect(options.launchLab).toBe(defaultServeOptions.launchLab);


### PR DESCRIPTION
I had issues with tasks I want to run before live reload kicks off, the startup tasks run during the livereload so if you have a build process that cleans out www, you can get errors with livereload being unable to read files and so on.

I considered making the startup tasks sync, but anyone with a custom watch task in the startup would find serve broken for them.

So I added the gulpDependantTasks option for ionic.project, these tasks need to finish before livereload and the startup tasks take place. I'm not married to the name.

What do you think?