### PR TITLE
Allow users to disable serving cordova.js mocks when using ionic serve

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -160,7 +160,8 @@ Serve.loadSettings = function loadSettings(argv, project) {
   options.launchBrowser = !argv.nobrowser && !argv.b;
   options.launchLab = options.launchBrowser && (argv.lab || argv.l);
   options.runLivereload = !(argv.nolivereload || argv.d);
-  
+  options.mockCordova = !(argv.nocordovamock || argv.m);
+
   var noProxyFlag = argv.noproxy || argv.x || false;
   var proxies = project.get('proxies') || [];
 
@@ -355,7 +356,7 @@ Serve.startServer = function startServer(options, app) {
     var platformOverride = urlParsed.query && urlParsed.query.ionicplatform;
 
     var platformUrl = getPlatformUrl(req);
-    if(platformUrl) {
+    if(options.mockCordova && platformUrl) {
       var platformWWW = path.join(options.appDirectory, getPlatformWWW(req));
       // var platformWWW = path.join(options.appDirectory, platformWWW);
 


### PR DESCRIPTION
This PR adds a `--nocordovamock` parameter to ionic serve to allow users to provide their own cordova.js, cordova_plugins.js, etc while using ionic serve.

As requested in https://github.com/driftyco/ionic-cli/issues/354

Here's a version of the ionic-cli on npm for testing this feature: https://www.npmjs.com/package/ionic-no-cordova-mock