### PR TITLE
Make saved ionic.project end with a newline

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -71,7 +71,7 @@ Project.save = function save(appDirectory, data) {
     var filePath = path.join(appDirectory, Project.PROJECT_FILE);
         jsonData = JSON.stringify(data, null, 2);
     
-    fs.writeFileSync(filePath, jsonData);
+    fs.writeFileSync(filePath, jsonData + '\n');
   } catch(e) {
     console.error('Unable to save settings file:', e);
   }


### PR DESCRIPTION
As per https://github.com/driftyco/ionic-cli/issues/271
For `package.json` it was already fixed in https://github.com/driftyco/ionic-app-lib/pull/16