### PR TITLE
Ensures function parameter 'variables' is an array

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -633,6 +633,11 @@ State.savePlugin = function savePlugin(appDirectory, pluginId, variables) {
     return State.savePackageJson(appDirectory, packageJson);
   }
 
+  // This is necessary to ensure variables is actually an array
+  if (typeof variables == 'string') {
+    variables = [ variables ];
+  }
+
   //Check and save for variables
   pluginInfo.variables = {};
   for (var i = 0, j = variables.length; i < j; i++)  {


### PR DESCRIPTION
Under some circumstances the parameter 'variables' of the
State.savePlugin function may be a string instead of an
array as expected.  This commit will ensure the parameter is
an array before attempting to process the contents.

This addresses issue #25 