### PR TITLE
Throw exception when plugin installation fails during 'state reset'

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -535,8 +535,11 @@ State.processPlugin = function processPlugin(appDirectory, index, packageJson, p
     var plugin = packageJson.cordovaPlugins[index];
     var pluginCommand = State.createAddRemoveStatement(plugin);
     logging.logger.info(pluginCommand);
-    exec(pluginCommand, function() {
-        State.processPlugin(appDirectory, index + 1, packageJson, promise);
+    shelljs.exec(pluginCommand, {async: true}, function(code, output) {
+      if (code != 0) {
+        throw 'Error executing "' + pluginCommand + '":\n' + output;
+      }
+      State.processPlugin(appDirectory, index + 1, packageJson, promise)
     });
   } catch (ex) {
     logging.logger.error('An error happened processing the previous cordova plugins')


### PR DESCRIPTION
### TL;DR ###
The previous implementation silently ignored errors when installing plugins via `ionic state reset`, since the return code of the shell invocation was not checked.
This PR adds an exception that is thrown whenever a plugin installation fails.

### Full explanation ###

**Problem:**

When running `ionic state reset`, failed plugin installations are silently ignored and not visible. The previous code has a block to catch exceptions, but `exec` doesn't throw any exceptions when the invoked command returns an error.

This is especially annoying since `ionic plattform add` seems to install plugins in a different way, so depending on what you do, you see errors or you don't.

**How to reproduce:**

Put an invalid plugin name into your `package.json` and run `ionic state reset`. The command will show the installation in the terminal ("`cordova plugin add some-non-existent-plugin`"), but it will not do this of course.

This is very annoying since an existing setup can easily fail. For example when you are fetching a new version of this plugin that suddenly requires different platform versions etc.
The only way to find out is to go into the platforms directory and check if all plugins are really there.

**Solution:**
Check the return code of the shell invocation and throw an exception with the processes' output.

*(I tried to get the exit code from nodeJS's `exec` command (similar syntax, you have three parameters in the callback), but it was empty regardless of the outcome. Since shelljs is used anyway, I used they `exec` function and it works.)*