### PR TITLE
Do not use livereload on proxies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  pre:
+    - npm install -g gulp

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -526,15 +526,15 @@ Serve.start = function start(options) {
         options.childProcess = Serve.gulpStartupTasks(options);
       }
     })
-    .then(function() {
-      return Serve.runLivereload(options, app);
-    })
     .then(function(server) {
       logging.logger.info('Running live reload server:'.green.bold, options.liveReloadServer);
       logging.logger.info('Watching:'.green.bold, options.watchPatterns);
       if (options.useProxy) {
         return Serve.setupProxy(options, app);
       }
+    })
+    .then(function() {
+      return Serve.runLivereload(options, app);
     })
     .then(function(data) {
       return Serve.startServer(options, app);


### PR DESCRIPTION
# Description of change
Currently the livereload middleware is laoded before the proxies,
meaning that each proxy is going to have the livereload script added.

This breaks proxies that are using gzip encoding, and we do not need
the livereload script added to proxied endpoints.

# Steps to reproduce:

1. Add a proxy that uses compression such as gzip to `ionic.project` (in my case I was using the loopback framework, but you could make a simple server with express and use the `compression()` library, you'll need to ensure it's definitely serving gzipped content).
2. Add the proxy to `ionic.project`'s `proxies` key
3. Try and use the proxy, you'll notice you'll get a content encoding mismatch error. The error is in all browsers, curl, and probably other utilities. The error is because the body is gzipped, and the livereload script is not. I had to use wireshark to figure this out.