### PR TITLE
Add resource support for 'windows' platform

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -26,7 +26,7 @@ var Settings = {
   iconSourceFile: 'icon',
   splashSourceFile: 'splash',
   sourceExtensions: ['psd', 'ai', 'png'],
-  supportedPlatforms: ['android', 'ios', 'wp8'],
+  supportedPlatforms: ['android', 'ios', 'wp8', 'windows'],
   configFile: 'config.xml',
   generateThrottle: 4,
   defaultMaxIconSize: 96,
@@ -125,7 +125,35 @@ var Platforms = {
       nodeName: 'splash',
       nodeAttributes: ['src', 'width', 'height']
     }
-  }
+  },
+  
+  windows: {
+    icon: {
+      images: [
+        { name: 'Square30x30Logo.scale-100.png',        width: 30,  height: 30 },
+        { name: 'Square44x44Logo.scale-240.png',        width: 106, height: 106 },
+        { name: 'Square44x44Logo.scale-100.png',        width: 44,  height: 44 },
+        { name: 'Square70x70Logo.scale-100.png',        width: 70,  height: 70 },
+        { name: 'Square71x71Logo.scale-240.png',        width: 170, height: 170 },
+        { name: 'Square71x71Logo.scale-100.png',        width: 71,  height: 71 },
+        { name: 'Square150x150Logo.scale-240.png',      width: 360, height: 360 },
+        { name: 'Square150x150Logo.scale-100.png',      width: 150, height: 150 },
+        { name: 'Square310x310Logo.scale-100.png',      width: 310, height: 310 },
+        { name: 'StoreLogo.scale-240.png',              width: 120, height: 120 },
+        { name: 'StoreLogo.scale-100.png',              width: 50,  height: 50 }
+      ],
+      nodeName: 'icon',
+      nodeAttributes: ['src', 'width', 'height']
+    },
+    splash: {
+      images: [
+        { name: 'SplashScreen.scale-240.png',     width: 1152, height: 1920 },
+        { name: 'SplashScreen.scale-100.png',     width: 620,  height: 300 }
+      ],
+      nodeName: 'splash',
+      nodeAttributes: ['src', 'width', 'height']
+    }
+  },
 
 };
 


### PR DESCRIPTION
This updates the images used by Cordova.  There are a lot more image sizes that Windows/WP8.1 support but Cordova doesn't.

This works well for icons and the splash screen but for the Wide310x150Logo the image generated is pretty bad so I didn't include it.

        { name: 'Wide310x150Logo.scale-240.png',        width: 744, height: 360 },
        { name: 'Wide310x150Logo.scale-100.png',        width: 310, height: 150 }