### PR TITLE
Close gulp https://github.com/driftyco/ionic-cli/issues/570.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -38,6 +38,10 @@ Serve.listenForServerCommands = function listenForServerCommands(options) {
   var readline = require('readline');
 
   process.on("SIGINT", function(){
+    if (options.childProcess) {
+      logging.logger.info('Closing Gulp process'.yellow);
+      options.childProcess.kill('SIGTERM');
+    }
     process.exit();
   });
 
@@ -102,11 +106,7 @@ Serve.listenForServerCommands = function listenForServerCommands(options) {
     // logging.logger.debug('input: ', input);
     rl.prompt();
   }).on('close', function() {
-    if (options.childProcess) {
-      logging.logger.info('Closing Gulp process'.yellow);
-      options.childProcess.kill('SIGTERM');
-    }
-    process.exit(0);
+    process.emit('SIGINT');
   });
 
 }


### PR DESCRIPTION
Fixes issue https://github.com/driftyco/ionic-cli/issues/570. Child gulp processes are not closed when exited from the terminal via ctrl-c. 
