### PR TITLE
fix easy jshint errors

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -157,7 +157,7 @@ Browser.downloadCordovaCrosswalkEngine = function downloadCordovaCrosswalkEngine
   }, function(error) {
     logging.logger.error('Failed to download cordova-crosswalk-engine - %s', error, {});
     q.reject();
-  })
+  });
 
   return q.promise;
 };
@@ -244,7 +244,7 @@ Browser.downloadCrosswalkWebviews = function downloadCrosswalkWebviews(appDirect
   // logging.logger.debug('xwalk', xwalkVersion)
 
   if (!xwalkVersion) {
-    logging.logger.error('\nYou must specify a valid version from crosswalk. Run `ionic browser list` to see versions')
+    logging.logger.error('\nYou must specify a valid version from crosswalk. Run `ionic browser list` to see versions');
     // q.reject('You must specify a valid version from crosswalk. Run `ionic browser list` to see versions')
     throw new Error('Invalid version of Crosswalk specified');
   }
@@ -293,7 +293,7 @@ Browser.downloadCordova40x = function downloadCordova40x(appDirectory) {
   }, function(error) {
     logging.logger.error('Failed to download cordova-android v4.0.x - %s', error, {});
     q.reject();
-  })
+  });
 
   return q.promise;
 };
@@ -316,7 +316,7 @@ Browser.removeAndroidProject = function removeAndroidProject(appDirectory, saveT
   return Cordova.removePlatform(appDirectory, 'android', saveToPackageJson)
   .then(function() {
     logging.logger.info('\nRemoved old Cordova Android platform');
-  })
+  });
 };
 
 Browser.addCordova40xProject = function addCordova40xProject(appDirectory, saveToPackageJson) {
@@ -408,7 +408,7 @@ Browser.downloadFiles = function downloadFiles(appDirectory, version, isLiteVers
   });
 
   // return q.promise;
-}
+};
 
 Browser.removeCrosswalk = function removeCrosswalk(appDirectory) {
   var cwd = shelljs.pwd();
@@ -451,7 +451,7 @@ Browser.installCrosswalk = function installCrosswalk(appDirectory, version, save
     return Q(cordovaMessage);
   } else if (semver.satisfies(info.cordova, '>=5.0.0')) {
     return Browser.installCordovaCrosswalk(appDirectory);
-  } 
+  }
 
   logging.logger.info(('You are running Cordova CLI ' + info.cordova + ' - installing Cordova Android and Crosswalk manually').yellow.bold);
 
@@ -503,12 +503,12 @@ Browser.upgradeCrosswalk = function upgradeCrosswalk(appDirectory) {
 Browser.revertBrowser = function revertBrowser(appDirectory, platform) {
   if (!platform) {
     logging.logger.info('You did not specify a platform to revert the browser');
-    return
+    return;
   }
 
   if(platforms.indexOf(platform) == -1) {
     logging.logger.info('You did not specify a valid platform.');
-    return
+    return;
   }
 
   logging.logger.info('Reverting', platform, 'browser');
@@ -570,7 +570,7 @@ Browser.saveBrowserInstallation = function saveBrowserInstallation(platform, bro
 
 Browser.addBrowser = function addBrowser(appDirectory, browserToInstall, saveToPackageJson) {
 
-  if (!appDirectory) { 
+  if (!appDirectory) {
     throw 'You must pass a directory to run this command';
   }
 
@@ -653,6 +653,7 @@ var printBrowsers = function printBrowsers(browsers) {
     var browser = browsers[x];
     var avail = browser.available ? 'Yes' : 'No';
     var installCommand = browser.command ? browser.command : '';
+    var version;
 
     if (browser.available) {
       logging.logger.info('\nAvailable'.green.bold, '-', browser.name.green, '-', installCommand);
@@ -663,9 +664,9 @@ var printBrowsers = function printBrowsers(browsers) {
           var betaCanaryMessage = null;
 
           if (ver.beta) {
-            betaCanaryMessage = '(beta)\t'
+            betaCanaryMessage = '(beta)\t';
           } else if (ver.canary) {
-            betaCanaryMessage = '(canary)'
+            betaCanaryMessage = '(canary)';
           } else {
             betaCanaryMessage = '\t';
           }
@@ -695,6 +696,7 @@ Browser.listInstalledBrowsers = function listInstalledBrowsers(appDirectory) {
   var project = IonicProject.load();
 
   var browsers = project.get('browsers');
+  var browserIndex;
 
   logging.logger.info('\nInstalled browsers:\n'.green);
 

--- a/lib/config-xml.js
+++ b/lib/config-xml.js
@@ -88,5 +88,5 @@ ConfigXml.setConfigXml = function setConfigXml(appDirectory, options) {
         configString = xmlBuilder.buildObject(configJson);
         fs.writeFileSync(configXmlPath, configString);
       }
-    })
+    });
 };

--- a/lib/cordova.js
+++ b/lib/cordova.js
@@ -177,7 +177,7 @@ Cordova.setupLiveReload = function() {
   })
   .catch(function(error) {
 
-  })
+  });
 
   return d.promise;
 };
@@ -185,7 +185,7 @@ Cordova.setupLiveReload = function() {
 
 Cordova.addPlatform = function addPlatform(projectRoot, platform, savePlatform) {
   logging.logger.debug('Cordova.addPlatform: ', projectRoot, platform, savePlatform);
-  // var opts = { 
+  // var opts = {
   //   searchpath : args.searchpath
   //   , noregistry : args.noregistry
   //   , usegit : args.usegit
@@ -198,7 +198,7 @@ Cordova.addPlatform = function addPlatform(projectRoot, platform, savePlatform) 
   var options = {
     stdio: 'pipe'
   };
-  
+
   var originalPwd = process.env.PWD;
   process.env.PWD = projectRoot;
 
@@ -256,7 +256,7 @@ Cordova.addPlugin = function addPlugin(projectRoot, pluginId, pluginVariables, s
   var originalPwd = process.env.PWD;
   process.env.PWD = projectRoot;
 
-  // If you need to pass variables, 
+  // If you need to pass variables,
   //target should be an array of [plugin_id, '--variable', 'VARNAME=value']
   //require('cordova-lib').cordova.raw.plugin('add', target)
   return cordova.plugin('add', pluginId, {stdio: 'pipe'})

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -82,12 +82,12 @@ Hooks.add = function add(appDirectory) {
     }
   });
 
-  logging.logger.info('Added default Ionic Cordova hooks'.green.bold)
+  logging.logger.info('Added default Ionic Cordova hooks'.green.bold);
 
 };
 
 Hooks.remove = function remove(appDirectory) {
-  logging.logger.info('Removing the Ionic Cordova plugin hooks'.blue.bold)
+  logging.logger.info('Removing the Ionic Cordova plugin hooks'.blue.bold);
   var oldPluginHooks = [
     'after_platform_add/010_install_plugins.js',
     'after_plugin_add/010_register_plugin.js',
@@ -99,7 +99,7 @@ Hooks.remove = function remove(appDirectory) {
       var hookPath = path.join(appDirectory, 'hooks', hook);
       fs.unlinkSync(hookPath);
     } catch(ex) { }
-  })
+  });
 
   logging.logger.info('Removed the Ionic Cordova hooks'.green.bold);
 
@@ -131,7 +131,7 @@ Hooks.setHooksPermission = function setHooksPermission(appDirectory) {
         } catch(e) {
           logging.logger.error('Hooks.setHooksPermission fs.chmodSync: %s'.error, e, {});
         }
-      })
+      });
     });
   } catch (ex) {
     logging.logger.error('Error: %s', ex);

--- a/lib/hooks/after_platform_add/010_install_plugins.js
+++ b/lib/hooks/after_platform_add/010_install_plugins.js
@@ -13,8 +13,8 @@ var packageJSON = null;
 try {
   packageJSON = require('../../package.json');
 } catch(ex) {
-  console.log('\nThere was an error fetching your package.json file.')
-  console.log('\nPlease ensure a valid package.json is in the root of this project\n')
+  console.log('\nThere was an error fetching your package.json file.');
+  console.log('\nPlease ensure a valid package.json is in the root of this project\n');
   return;
 }
 

--- a/lib/hooks/after_plugin_add/010_register_plugin.js
+++ b/lib/hooks/after_plugin_add/010_register_plugin.js
@@ -30,7 +30,7 @@ process.env.CORDOVA_PLUGINS.split(',').forEach(function (plugin) {
 
       configString = fs.readFileSync(pluginXmlPath,{encoding: 'utf8'});
       idRegEx = new RegExp('<plugin[^>]*id="(.*)"', 'i');
-      id = idRegEx.exec(configString)[1]
+      id = idRegEx.exec(configString)[1];
       pluginToAdd = {id: id, locator: plugin};
     } catch(ex) {
       console.log('There was an error retrieving the plugin.xml filr from the 010_register_plugin.js hook', ex);
@@ -47,7 +47,7 @@ process.env.CORDOVA_PLUGINS.split(',').forEach(function (plugin) {
       if(typeof checkPlugin == 'object' && checkPlugin.id == pluginToAdd.id) {
         pluginExists = true;
       }
-    })
+    });
     if(!pluginExists) {
       packageJSON.cordovaPlugins.push(pluginToAdd);
     }

--- a/lib/info.js
+++ b/lib/info.js
@@ -13,7 +13,7 @@ var Info = module.exports;
 var requirements = {
   node: '>=0.12.x',
   cordova: '>=4.2.0'
-}
+};
 
 Info.getMacInfo = function getMacInfo() {
   //Need to get:
@@ -53,7 +53,7 @@ Info.getMacInfo = function getMacInfo() {
 Info.getCordovaInfo = function getCordovaInfo(info) {
   var command = 'cordova -v';
   var result = shelljs.exec(command, { silent: true });
-  if(result.code != 0) {
+  if(result.code !== 0) {
     info.cordova = 'Not installed';
     return;
   }
@@ -63,28 +63,28 @@ Info.getCordovaInfo = function getCordovaInfo(info) {
 
 Info.getXcodeInfo = function getXcodeInfo() {
   var result = shelljs.exec('/usr/bin/xcodebuild -version', { silent: true });
-  if(result.code != 0) {
+  if(result.code !== 0) {
     return 'Not installed';
   }
-  var version = result.output.replace(/\n/g, ' ')
+  var version = result.output.replace(/\n/g, ' ');
   return version;
 };
 
 Info.getIosSimInfo = function getIosSimInfo() {
   var result = shelljs.exec('ios-sim --version', { silent: true });
-  if(result.code != 0) {
+  if(result.code !== 0) {
     return 'Not installed';
   }
-  var version = result.output.replace(/\n/g, ' ')
+  var version = result.output.replace(/\n/g, ' ');
   return version;
 };
 
 Info.getIosDeployInfo = function getIosDeployInfo() {
   var result = shelljs.exec('ios-deploy --version', { silent: true });
-  if(result.code != 0) {
+  if(result.code !== 0) {
     return 'Not installed';
   }
-  var version = result.output.replace(/\n/g, ' ')
+  var version = result.output.replace(/\n/g, ' ');
   return version;
 };
 
@@ -106,16 +106,18 @@ Info.getIonicLibVersion = function getIonicLibVersion(info) {
 };
 
 Info.getIonicVersion = function getIonicVersion(info, appDirectory) {
+  var ionicVersion;
+
   try {
     var ionicVersionFile = require(path.join(appDirectory, 'www/lib/ionic/version.json'));
-    var ionicVersion = ionicVersionFile.version;
+    ionicVersion = ionicVersionFile.version;
     info.ionic = ionicVersion;
   } catch (ex) { }
 
   try {
     var bowerJsonPath = path.join(appDirectory, 'www', 'lib', 'ionic', 'bower.json');
     var ionicPackageJson = require(bowerJsonPath);
-    var ionicVersion = ionicPackageJson.version;
+    ionicVersion = ionicPackageJson.version;
     info.ionic = ionicVersion;
   } catch (ex) { }
 
@@ -170,7 +172,7 @@ Info.getWindowsEnvironmentInfo = function getWindowsEnvironmentInfo() {
 
 Info.getLinuxEnvironmentInfo = function getLinuxEnvironmentInfo() {
   var result = shelljs.exec('lsb_release -id', { silent: true });
-  return result.output.replace(/\n/g, ' ')
+  return result.output.replace(/\n/g, ' ');
 };
 
 //http://stackoverflow.com/questions/6551006/get-my-os-from-the-node-js-shell
@@ -202,7 +204,7 @@ Info.gatherGulpInfo = function gatherGulpInfo(info) {
   var result = shelljs.exec('gulp -v', { silent: true });
 
   try {
-    if (result.code == 0) {
+    if (result.code === 0) {
       // console.log(result.output);
       var gulpVersions = result.output.replace(/(\[.*\])/g, '').split('\n');
       if (gulpVersions.length > 0) {
@@ -272,7 +274,7 @@ Info.printInfo = function printInfo(info) {
   }
 
   if (info.ios_deploy) {
-    logging.logger.info('ios-deploy version:', info.ios_deploy)
+    logging.logger.info('ios-deploy version:', info.ios_deploy);
   }
 
   if(info.ios_sim) {
@@ -299,11 +301,11 @@ Info.checkRuntime = function checkRuntime() {
       validRuntime = true;
 
   try {
-    nodeUpgrade = !semver.satisfies(info.node, requirements.node);  
+    nodeUpgrade = !semver.satisfies(info.node, requirements.node);
     cordovaUpgrade = !semver.satisfies(info.cordova, requirements.cordova);
     cordovaInstalled = true; //if it throws above, we know cordova is not installed
-  } catch (ex) { 
-  } 
+  } catch (ex) {
+  }
 
   logging.logger.debug('System Info:', info);
 
@@ -328,14 +330,14 @@ Info.checkRuntime = function checkRuntime() {
     logging.logger.info('');
 
     if(nodeUpgrade) {
-      var updateMessage = [' Please update your Node runtime to version ', requirements.node].join(' ');
-      logging.logger.info(updateMessage.red.bold);
+      var updateNodeMessage = [' Please update your Node runtime to version ', requirements.node].join(' ');
+      logging.logger.info(updateNodeMessage.red.bold);
       validRuntime = false;
     }
 
     if(!cordovaInstalled || cordovaUpgrade) {
       var action = cordovaInstalled ? 'update' : 'install';
-      var updateMessage = [' Please', action, 'your Cordova CLI to version ', requirements.cordova, '`npm install -g cordova`'].join(' ')
+      var updateMessage = [' Please', action, 'your Cordova CLI to version ', requirements.cordova, '`npm install -g cordova`'].join(' ');
       logging.logger.info(updateMessage.red.bold);
       validRuntime = false;
     }

--- a/lib/io-config.js
+++ b/lib/io-config.js
@@ -25,10 +25,10 @@ var IoConfig = module.exports;
 
 var CORE_FILE = './www/lib/ionic-platform-web-client/dist/ionic.io.bundle.js';
 var CORE_FILE_MIN = './www/lib/ionic-platform-web-client/dist/ionic.io.bundle.min.js';
-var CONFIG_BACKUP = './.io-config.json'
+var CONFIG_BACKUP = './.io-config.json';
 var INDEX_FILE = './www/index.html';
 var APP_FILE = './www/js/app.js';
-var TMP_ERR = './errors.html'
+var TMP_ERR = './errors.html';
 var IO_COMPONENTS = {
   'ionic-platform-web-client': {
     name: 'ionic.service.core',
@@ -83,7 +83,7 @@ IoConfig.isCoreAvailable = function isCoreAvailable() {
     }
   });
   return deferred.promise;
-}
+};
 
 IoConfig.doesHaveKey = function doesHaveKey(key) {
   var deferred = Q.defer();
@@ -100,7 +100,7 @@ IoConfig.doesHaveKey = function doesHaveKey(key) {
     }
   });
   return deferred.promise;
-}
+};
 
 IoConfig.listConfig = function listConfig() {
   fs.readFile(CONFIG_BACKUP, function(err, data) {
@@ -128,7 +128,7 @@ IoConfig.listConfig = function listConfig() {
       });
     }
   });
-}
+};
 
 IoConfig.warnMissingData = function warnMissingData() {
   var deferred = Q.defer();
@@ -139,60 +139,61 @@ IoConfig.warnMissingData = function warnMissingData() {
     } else if (data) {
       jsonObj = JSON.parse(data);
       var safe = true;
-      if (!jsonObj['app_id'] || !jsonObj['api_key']) {
+      if (!jsonObj.app_id || !jsonObj.api_key) {
         safe = false;
       }
       deferred.resolve(safe);
     }
   });
   return deferred.promise;
-}
+};
 
 IoConfig.writeIoConfig = function writeIoConfig(key, val, set) {
   var deferred = Q.defer();
-  if (ALLOWED_CONFIG[key] || key == false) {
+  var jsonObj;
+  if (ALLOWED_CONFIG[key] || key === false) {
     var type = 'undefined';
-    if (!key == false) {
+    if (!key === false) {
       type = ALLOWED_CONFIG[key].type;
     }
     fs.readFile(CONFIG_BACKUP, function(err, data) {
       if (err) {
         if (err.code === 'ENOENT') {
-          var jsonObj = {};
+          jsonObj = {};
           if (key && set) {
             if (type === 'boolean') {
               if (val === 'true') {
-                jsonObj[key] = true
+                jsonObj[key] = true;
               } else {
-                jsonObj[key] = false
+                jsonObj[key] = false;
               }
             } else if (type === 'string') {
               jsonObj[key] = String(val);
             } else {
-              jsonObj[key] = val
+              jsonObj[key] = val;
             }
           }
         } else {
           deferred.reject(new Error(err));
         }
       } else {
-        var jsonObj = JSON.parse(data);
+        jsonObj = JSON.parse(data);
         if (key) {
           if (set) {
             if (type === 'boolean') {
               if (val === 'true') {
-                jsonObj[key] = true
+                jsonObj[key] = true;
               } else {
-                jsonObj[key] = false
+                jsonObj[key] = false;
               }
             } else if (type === 'string') {
               jsonObj[key] = String(val);
             }
             else {
-              jsonObj[key] = val
+              jsonObj[key] = val;
             }
           } else if (!set && jsonObj[key]) {
-            delete jsonObj[key]
+            delete jsonObj[key];
           }
         }
       }
@@ -203,14 +204,14 @@ IoConfig.writeIoConfig = function writeIoConfig(key, val, set) {
           if (key) {
             logging.logger.info("Saved " + key + ", writing to ionic.io.bundle.min.js...");
           } else {
-            logging.logger.info('Building platform config...')
+            logging.logger.info('Building platform config...');
           }
           IoConfig.isCoreAvailable().then(function(available) {
             if (available) {
               fs.readFile(CORE_FILE_MIN, function(er, content) {
                 var jsMinFile = String(content);
                 var replacementString = "var settings = " + JSON.stringify(jsonObj) + "; " + SETTINGS_REPLACEMENT;
-                jsMinFile = jsMinFile.replace(new RegExp('(' + SETTINGS_REPLACE_START + ')(.*?)(' + SETTINGS_REPLACE_END + ')', 'g'), '$1' + replacementString + '$3')
+                jsMinFile = jsMinFile.replace(new RegExp('(' + SETTINGS_REPLACE_START + ')(.*?)(' + SETTINGS_REPLACE_END + ')', 'g'), '$1' + replacementString + '$3');
                 if (jsMinFile) {
                   fs.writeFile(CORE_FILE_MIN, jsMinFile, function(e){
                     if (e) {
@@ -227,7 +228,7 @@ IoConfig.writeIoConfig = function writeIoConfig(key, val, set) {
               fs.readFile(CORE_FILE, function(er, content) {
                 var jsFile = String(content);
                 var replacementString = "var settings = " + JSON.stringify(jsonObj) + "; " + SETTINGS_REPLACEMENT;
-                jsFile = jsFile.replace(new RegExp('(' + SETTINGS_REPLACE_START + ')(.*?)(' + SETTINGS_REPLACE_END + ';)', 'g'), '$1' + replacementString + '$3')
+                jsFile = jsFile.replace(new RegExp('(' + SETTINGS_REPLACE_START + ')(.*?)(' + SETTINGS_REPLACE_END + ';)', 'g'), '$1' + replacementString + '$3');
                 if (jsFile) {
                   fs.writeFile(CORE_FILE, jsFile, function(e){
                     if (e) {
@@ -416,7 +417,7 @@ IoConfig.initIoPlatform = function initIoPlatform(appDirectory, jar) {
   } catch(ex) {
     logging.logger.error("Error initializing app: %s", ex, {});
   }
-}
+};
 
 IoConfig.dashInit = function dashInit(project, jar) {
   var q = Q.defer();

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -16,11 +16,12 @@ Logging.logger = new winston.Logger({
 // To be used by helpers createDefaultLogger and createLoggerWithFile
 Logging.createLogger = function createLogger(transports, level) {
   level = level || 'info';
-  return Logging.logger = new winston.Logger({
+  Logging.logger = new winston.Logger({
     exitOnError: false,
     level: level,
     transports: transports
   });
+  return Logging.logger;
 };
 
 Logging.createDefaultLogger = function createDefaultLogger(level) {
@@ -38,7 +39,7 @@ Logging.createLoggerWithFile = function createLoggerWithFile(logFilePath, level)
   var transports = [
     new (winston.transports.File)({
       filename: logFilePath,
-      name: 'file' 
+      name: 'file'
     })
   ];
   return Logging.createLogger(transports, level);
@@ -47,7 +48,7 @@ Logging.createLoggerWithFile = function createLoggerWithFile(logFilePath, level)
 Logging.queryLogs = function queryLogs(searchText, timestamp) {
   var searchDate = new Date(timestamp) || new Date();
   var options = {
-    from: new Date - 24 * 60 * 60 * 1000,
+    from: new Date() - 24 * 60 * 60 * 1000,
     until: searchDate,
     limit: 10,
     start: 0,

--- a/lib/login.js
+++ b/lib/login.js
@@ -275,5 +275,5 @@ Login.getDownloadLink = function getDownloadLink(jar, appId) {
       q.reject(ex);
     }
   });
-  return q.promise;  
+  return q.promise;
 };

--- a/lib/multibar.js
+++ b/lib/multibar.js
@@ -25,13 +25,13 @@ Multibar.prototype = {
     bar.oterminate = bar.terminate;
     bar.tick = function(value, options) {
       self.tick(index, value, options);
-    }
+    };
     bar.terminate = function() {
       self.terminates++;
       if (self.terminates == self.bars.length) {
         self.terminate();
       }
-    }
+    };
 
     return bar;
   },
@@ -55,7 +55,7 @@ Multibar.prototype = {
       bar.otick(value, options);
     }
   }
-}
+};
 
 // var mbars = new Multibar();
 // var bars  = [];

--- a/lib/opbeat.js
+++ b/lib/opbeat.js
@@ -18,7 +18,7 @@ Opbeat.cliClientOptions = {
   appId: '1a3f490314',
   secretToken: 'f058c32e757d3c589c3c1a7236767a307b780d0b',
   clientLogLevel: 'fatal',
-  prerequestMethod: Opbeat.reportExtras 
+  prerequestMethod: Opbeat.reportExtras
 };
 
 Opbeat.guiClientOptions = {

--- a/lib/package.js
+++ b/lib/package.js
@@ -165,7 +165,7 @@ Package.determineFileExtensionByPlatform = function(platform) {
   }
 
   throw new Error('Unknown platform: ' + platform);
-}
+};
 
 function build(appDirectory, jar, appId, profileTag, formDataExtra, options) {
   events.emit('package-start');
@@ -319,7 +319,7 @@ function build(appDirectory, jar, appId, profileTag, formDataExtra, options) {
 
       return buildId;
     });
-};
+}
 
 function sendProjectZip(appId, jar) {
   var q = Q.defer();
@@ -358,7 +358,7 @@ function uploadProjectZip(url, formData, projectZipPath) {
 
   _.extend(formData, {
     file: fs.createReadStream(projectZipPath)
-  })
+  });
 
   request.post({
     url: url,

--- a/lib/ports.js
+++ b/lib/ports.js
@@ -4,7 +4,7 @@
  * (C) 2011, Charlie Robbins
  *
  */
- 
+
 var fs = require('fs'),
     net = require('net'),
     path = require('path'),
@@ -21,14 +21,14 @@ exports.basePort = 8000;
 // ### @basePath {string}
 // Default path to begin any socket search from
 //
-exports.basePath = '/tmp/portfinder'
+exports.basePath = '/tmp/portfinder';
 
 exports.getPort = function (options, callback) {
   if (!callback) {
     callback = options;
-    options = {}; 
+    options = {};
   }
-  
+
   options.port   = options.port   || exports.basePort;
   options.host   = options.host   || null;
   options.server = options.server || net.createServer(function () {
@@ -36,13 +36,13 @@ exports.getPort = function (options, callback) {
     // Create an empty listener for the port testing server.
     //
   });
-  
+
   function onListen () {
     options.server.removeListener('error', onError);
     options.server.close();
     callback(null, options.port);
   }
-  
+
   function onError (err) {
     options.server.removeListener('listening', onListen);
 
@@ -100,7 +100,7 @@ exports.getSocket = function (options, callback) {
 
   options.mod  = options.mod    || 0755;
   options.path = options.path   || exports.basePath + '.sock';
-  
+
   //
   // Tests the specified socket
   //
@@ -128,7 +128,7 @@ exports.getSocket = function (options, callback) {
       }
     });
   }
-  
+
   //
   // Create the target `dir` then test connection
   // against the socket.
@@ -138,21 +138,21 @@ exports.getSocket = function (options, callback) {
       if (err) {
         return callback(err);
       }
-      
+
       options.exists = true;
       testSocket();
     });
   }
-  
+
   //
   // Check if the parent directory of the target
   // socket path exists. If it does, test connection
   // against the socket. Otherwise, create the directory
-  // then test connection. 
+  // then test connection.
   //
   function checkAndTestSocket () {
     var dir = path.dirname(options.path);
-    
+
     fs.stat(dir, function (err, stats) {
       if (err || !stats.isDirectory()) {
         return createAndTestSocket(dir);
@@ -162,21 +162,19 @@ exports.getSocket = function (options, callback) {
       testSocket();
     });
   }
-  
+
   //
-  // If it has been explicitly stated that the 
-  // target `options.path` already exists, then 
+  // If it has been explicitly stated that the
+  // target `options.path` already exists, then
   // simply test the socket.
   //
-  return options.exists 
-    ? testSocket()
-    : checkAndTestSocket();
+  return options.exists ? testSocket() : checkAndTestSocket();
 };
 
 //
 // ### function nextPort (port)
 // #### @port {Number} Port to increment from.
-// Gets the next port in sequence from the 
+// Gets the next port in sequence from the
 // specified `port`.
 //
 exports.nextPort = function (port) {
@@ -186,7 +184,7 @@ exports.nextPort = function (port) {
 //
 // ### function nextSocket (socketPath)
 // #### @socketPath {string} Path to increment from
-// Gets the next socket path in sequence from the 
+// Gets the next socket path in sequence from the
 // specified `socketPath`.
 //
 exports.nextSocket = function (socketPath) {
@@ -195,11 +193,11 @@ exports.nextSocket = function (socketPath) {
       match = name.match(/^([a-zA-z]+)(\d*)$/i),
       index = parseInt(match[2]),
       base = match[1];
-  
+
   if (isNaN(index)) {
     index = 0;
   }
-  
+
   index += 1;
   return path.join(dir, base + index + '.sock');
 };

--- a/lib/project.js
+++ b/lib/project.js
@@ -28,7 +28,7 @@ Project.wrap = function wrap(appDirectory, data) {
 };
 
 Project.load = function load(appDirectory) {
-  if (!appDirectory) { 
+  if (!appDirectory) {
     //Try to grab cwd
     appDirectory = process.cwd();
   }
@@ -41,7 +41,7 @@ Project.load = function load(appDirectory) {
       throw new Error('There was an error loading your ionic.project file: ' + ex.message);
     }
   } else if (fs.existsSync(path.join(appDirectory, 'www'))) {
-    var data = Project.PROJECT_DEFAULT;
+    data = Project.PROJECT_DEFAULT;
     var parts = path.join(appDirectory, '.').split(path.sep);
     var dirname = parts[parts.length-1];
     Project.create(appDirectory, dirname);
@@ -70,7 +70,7 @@ Project.save = function save(appDirectory, data) {
   try {
     var filePath = path.join(appDirectory, Project.PROJECT_FILE);
         jsonData = JSON.stringify(data, null, 2);
-    
+
     fs.writeFileSync(filePath, jsonData + '\n');
   } catch(e) {
     console.error('Unable to save settings file:', e);

--- a/lib/release.js
+++ b/lib/release.js
@@ -24,15 +24,15 @@ Release.start = function start(appDirectory, platform, compressImages) {
   var wwwPath;
 
   platform = platform || 'ios';
-      
+
   switch (platform) {
     case 'android':
       wwwPath = path.join(appDirectory, 'platforms', platform, 'assets', 'www');
       break;
-    case 'ios': 
+    case 'ios':
     case 'browser':
       wwwPath = path.join(appDirectory, 'platforms', platform, 'www');
-      break;        
+      break;
     default:
       logging.logger.info('Release only supports android, ios, and browser currently');
       return;
@@ -46,7 +46,7 @@ Release.start = function start(appDirectory, platform, compressImages) {
   logging.logger.info('Scanning', indexPath);
   var content = fs.readFileSync(indexPath).toString();
   var blocks = useminLib.getBlocks(indexPath, content, removeLivereload);
-  
+
   // logging.logger.info(blocks);
 
   var process = useminLib.processBlocks(blocks, wwwPath);
@@ -59,14 +59,14 @@ Release.start = function start(appDirectory, platform, compressImages) {
     // logging.logger.info(block);
     block.src.forEach(function(srcItem) {
       filesList.push(srcItem);
-    })
+    });
   });
 
   try {
     var outIndexHtmlPath = path.join(wwwPath, 'index.html');
     logging.logger.info(wwwPath);
     fs.writeFileSync(outIndexHtmlPath, minifiedIndexHtml, 'utf8');
-    logging.logger.info('Wrote', outIndexHtmlPath)
+    logging.logger.info('Wrote', outIndexHtmlPath);
   } catch (ex) {
     logging.logger.info('ex');
     logging.logger.info(ex);
@@ -89,7 +89,7 @@ Release.start = function start(appDirectory, platform, compressImages) {
   var spawnOpts = {
     stdio: 'inherit'
   };
-  
+
   var child = child_process.spawn('node', [iosPath], spawnOpts);
 
   if (child.stdout) {

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -148,13 +148,13 @@ function generate(dir, options) {
   if (options.default) {
     if (hasExistingResources(appDirectory) && !options.force) {
       logging.logger.info('The resources folder already exists. We will not overwrite your files unless you pass the --force argument.'.red.bold);
-      logging.logger.info('Running with the force flag will overwrite your resources directory and modify your config.xml file'.red.bold)
+      logging.logger.info('Running with the force flag will overwrite your resources directory and modify your config.xml file'.red.bold);
       return Q.reject('RESOURCES_EXISTS');
     }
 
     return copyIconFilesIntoResources(appDirectory, options.force)
       .then(function() {
-        return addIonicIcons(appDirectory, 'ios')
+        return addIonicIcons(appDirectory, 'ios');
       })
       .then(function() {
         return addIonicIcons(appDirectory, 'android');
@@ -210,8 +210,8 @@ function generate(dir, options) {
       }
     }
 
-    if (options['api']) {
-      Settings.apiUrl = options['api'];
+    if (options.api) {
+      Settings.apiUrl = options.api;
     }
 
     var promises = [];
@@ -232,12 +232,7 @@ function generate(dir, options) {
       .then(loadSourceImages)
       .then(generateResourceImages)
       .then(loadResourceImages)
-// <<<<<<< HEAD:lib/resources/generate.js
-//       .then(updateConfigData)
-//       .catch(console.error);
-// =======
       .then(updateConfigData);
-// >>>>>>> package:lib/resources.js
 
   });
 }
@@ -865,7 +860,7 @@ function addIonicIcons(appDirectory, platform, forceAddResources) {
   var promise = null;
 
   if(forceAddResources) {
-    logging.logger.info('forceAddResources')
+    logging.logger.info('forceAddResources');
     promise = copyIconFilesIntoResources(appDirectory, forceAddResources);
   } else {
     promise = Q();
@@ -876,11 +871,11 @@ function addIonicIcons(appDirectory, platform, forceAddResources) {
       return getConfigData(appDirectory);
     })
     .then(function(data) {
-      if(!data.widget.platform || (data.widget.platform.length == 1 && data.widget.platform[0]['$'].name != platform)) {
-        logging.logger.info('Adding icons for platform:'.blue.bold, platform.green)
-        addPlatformIcons(platform, data)
-        addSplashScreenPreferences(data)
-        writeConfigData(appDirectory, data)
+      if(!data.widget.platform || (data.widget.platform.length == 1 && data.widget.platform[0].$.name != platform)) {
+        logging.logger.info('Adding icons for platform:'.blue.bold, platform.green);
+        addPlatformIcons(platform, data);
+        addSplashScreenPreferences(data);
+        writeConfigData(appDirectory, data);
       }
     });
 }
@@ -911,15 +906,15 @@ function copyIconFilesIntoResources(appDirectory, forceAddResources) {
   }
 
   var ionicResourcesUrl = 'https://github.com/driftyco/ionic-default-resources/archive/master.zip';
-  logging.logger.debug('uzip to: ', unzipPath)
+  logging.logger.debug('uzip to: ', unzipPath);
   logging.logger.info('Downloading Default Ionic Resources'.yellow);
   return Utils.fetchArchive(unzipPath, ionicResourcesUrl)
     .then(function() {
-      shelljs.config.silent = true
-      shelljs.mv('resources/ionic-default-resources-master/*', 'resources')
-      shelljs.rm('-rf', 'resources/ionic-default-resources-master')
-      logging.logger.info('Done adding default Ionic resources'.yellow)
-    })
+      shelljs.config.silent = true;
+      shelljs.mv('resources/ionic-default-resources-master/*', 'resources');
+      shelljs.rm('-rf', 'resources/ionic-default-resources-master');
+      logging.logger.info('Done adding default Ionic resources'.yellow);
+    });
 }
 
 function addPlatformIcons(platform, configData) {
@@ -933,9 +928,9 @@ function addPlatformIcons(platform, configData) {
   Platforms[platform].icon.images.forEach(function(image) {
     var iconDir = ['resources/', platform, '/icon/', image.name].join('');
     if (platform == 'android') {
-      platElem.icon.push({'$': { src: iconDir, density: image.density }})
+      platElem.icon.push({'$': { src: iconDir, density: image.density }});
     } else {
-      platElem.icon.push({'$': { src: iconDir, width: image.width, height: image.height }})
+      platElem.icon.push({'$': { src: iconDir, width: image.width, height: image.height }});
     }
   });
 
@@ -943,11 +938,11 @@ function addPlatformIcons(platform, configData) {
     //resources/ios/splash/
     var splashDir = ['resources/', platform, '/splash/', image.name].join('');
     if (platform == 'android') {
-      platElem.splash.push({'$': { src: splashDir, density: image.density }})
+      platElem.splash.push({'$': { src: splashDir, density: image.density }});
     } else {
-      platElem.splash.push({'$': { src: splashDir, height: image.height, width: image.width }})
+      platElem.splash.push({'$': { src: splashDir, height: image.height, width: image.width }});
     }
-  })
+  });
 }
 
 function addSplashScreenPreferences(configData) {
@@ -957,7 +952,7 @@ function addSplashScreenPreferences(configData) {
   var preferences = configData.widget.preference;
 
   if (!configData.widget.preference) {
-    configData.widget.preference = []
+    configData.widget.preference = [];
   }
 
   var hasSplashScreen = false, hasSplashScreenDelay = false;
@@ -969,7 +964,7 @@ function addSplashScreenPreferences(configData) {
     if (pref.$.name == 'SplashScreenDelay') {
       hasSplashScreenDelay = true;
     }
-  })
+  });
 
   if (!hasSplashScreen) {
     configData.widget.preference.push({'$': { name: 'SplashScreen', value: 'screen'}});

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,3 +1,5 @@
+/*jshint multistr: true */
+
 var fs = require('fs'),
     Q = require('q'),
     path = require('path'),
@@ -109,7 +111,7 @@ Serve.listenForServerCommands = function listenForServerCommands(options) {
     process.exit(0);
   });
 
-}
+};
 
 //isIonicServer = true when serving www directory, false when live reload
 Serve.checkPorts = function(isIonicServer, testPort, testHost, options) {
@@ -136,18 +138,18 @@ Serve.checkPorts = function(isIonicServer, testPort, testHost, options) {
   });
 
   return q.promise;
-}
+};
 
 //argv should be parsed out and put into a nice hash before getting here.
 Serve.loadSettings = function loadSettings(argv, project) {
-  
+  var errorMessage;
   if (!argv) {
-    var errorMessage = 'Serve.loadSettings - You must pass proper arguments to load settings from';
+    errorMessage = 'Serve.loadSettings - You must pass proper arguments to load settings from';
     logging.logger.info(errorMessage);
     throw new Error(errorMessage);
   }
   if (!project) {
-    var errorMessage = 'Serve.loadSettings - You must pass a project object to pull out project specific settings from';
+    errorMessage = 'Serve.loadSettings - You must pass a project object to pull out project specific settings from';
     logging.logger.info(errorMessage);
     throw new Error(errorMessage);
   }
@@ -219,7 +221,7 @@ Serve.openBrowser = function openBrowser(options) {
     var openUrl = options.launchLab ? [Serve.host(options.address, options.port), IONIC_LAB_URL] : [Serve.host(options.address, options.port)];
 
     if(options.browserOption) {
-      openUrl.push(options.browserOption)
+      openUrl.push(options.browserOption);
     }
 
     if (options.platform) {
@@ -232,7 +234,7 @@ Serve.openBrowser = function openBrowser(options) {
       logging.logger.info('Error opening the browser - ', ex);
     }
   }
-}
+};
 
 Serve.checkForDocumentRoot = function checkForDocumentRoot(options) {
   if (!fs.existsSync( path.join(options.appDirectory, options.documentRoot) )) {
@@ -246,7 +248,7 @@ Serve.checkForDocumentRoot = function checkForDocumentRoot(options) {
   }
 
   return true;
-}
+};
 
 Serve.gulpDependantTasks = function gulpDependantTasks(options) {
   var deferred = Q.defer();
@@ -266,7 +268,7 @@ Serve.gulpDependantTasks = function gulpDependantTasks(options) {
     deferred.resolve();
   }
   return deferred.promise;
-}
+};
 
 Serve.gulpStartupTasks = function gulpStartupTasks(options) {
   // gulpStartupTasks should be an array of tasks set in the project config
@@ -282,7 +284,7 @@ Serve.gulpStartupTasks = function gulpStartupTasks(options) {
     logging.logger.info('Gulp startup tasks:'.green.bold, tasks);
     return crossSpawn.spawn('gulp', tasks, { stdio: 'inherit' });
   }
-}
+};
 
 Serve.runLivereload = function runLivereload(options, app) {
   var q = Q.defer();
@@ -346,7 +348,7 @@ Serve.setupProxy = function setupProxy(options, app) {
       if (proxy.proxyNoAgent)
           opts.agent = false;
 
-      opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
+      opts.rejectUnauthorized = (proxy.rejectUnauthorized !== false);
 
       app.use(proxy.path, proxyMiddleware(opts));
       logging.logger.info('Proxy added:'.green.bold, proxy.path + " => " + url.format(proxy.proxyUrl));
@@ -449,7 +451,7 @@ Serve.startServer = function startServer(options, app) {
       fs.readFile(path.resolve(path.join(__dirname, 'assets/angular.min.js')), function(err, buf) {
         if(err) {
           res.end('404');
-        } 
+        }
         var jsFile = buf.toString('utf8');
         res.setHeader('Content-Type', 'application/javascript');
         res.end(jsFile);
@@ -517,7 +519,7 @@ Serve.start = function start(options) {
     return Q.when()
     .then(function() {
       if (!options.nogulp) {
-        return Serve.gulpDependantTasks(options)
+        return Serve.gulpDependantTasks(options);
       }
     })
     .then(function() {
@@ -628,7 +630,7 @@ Serve.consoleLog = function(req) {
         var isFirstLine = true;
 
         log.args.forEach(function(argObj){
-
+          var objKey;
           for(objKey in argObj) {
             if(isFirstLine) {
               isFirstLine = false;
@@ -822,7 +824,7 @@ Serve._goToHistory = function(goHistory, options) {
 
 
 Serve._postToLiveReload = function(files, options) {
-  var postUrl = [options.liveReloadServer, '/changed'].join('')
+  var postUrl = [options.liveReloadServer, '/changed'].join('');
   request.post(postUrl, {
     path: '/changed',
     method: 'POST',
@@ -835,7 +837,7 @@ Serve._postToLiveReload = function(files, options) {
     }
   });
 
-}
+};
 
 
 Serve.getAddress = function(options) {
@@ -898,7 +900,7 @@ Serve.getAddress = function(options) {
     }
 
     if (addresses.length > 0) {
-      
+
       if (!options.isPlatformServe) {
         addresses.push({
           address: 'localhost'
@@ -909,7 +911,7 @@ Serve.getAddress = function(options) {
         options.address = addresses[0].address;
         q.resolve();
         return q.promise;
-      } 
+      }
 
       logging.logger.info('\nMultiple addresses available.'.error.bold);
       logging.logger.info('Please select which address to use by entering its number from the list below:'.error.bold);
@@ -917,8 +919,8 @@ Serve.getAddress = function(options) {
         logging.logger.info('Note that the emulator/device must be able to access the given IP address'.small);
       }
 
-      for (var x=0; x < addresses.length; x++) {
-        logging.logger.info((' ' + (x+1) + ') ' + addresses[x].address + ( addresses[x].dev ? ' (' + addresses[x].dev + ')' : '' )).yellow);
+      for (var n = 0; n < addresses.length; n++) {
+        logging.logger.info((' ' + (n + 1) + ') ' + addresses[n].address + ( addresses[n].dev ? ' (' + addresses[n].dev + ')' : '' )).yellow);
       }
 
       var prompt = require('prompt');
@@ -997,4 +999,4 @@ Serve.stopServer = function stopServer() {
   } else {
     logging.logger.info('Server not running');
   }
-}
+};

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -68,7 +68,7 @@ Setup.modifyIndexFile = function modifyIndexFile(appDirectory) {
     if(!hasWatch) gulpStartupTasks.push('watch');
     project.set('gulpStartupTasks', gulpStartupTasks);
     if(!project.get('watchPatterns')){
-      project.set('watchPatterns', ['www/**/*', '!www/lib/**/*'])
+      project.set('watchPatterns', ['www/**/*', '!www/lib/**/*']);
     }
     project.save();
 
@@ -92,7 +92,7 @@ Setup.sassSetup = function sassSetup(appDirectory) {
   var q = Q.defer();
 
   if (!Utils.gulpInstalledGlobally()) {
-    var gulpMessage = ['You have specified Ionic CLI to set up sass.'.red, '\n', 'However, you do not have Gulp installed globally. Please run '.red, '`npm install -g gulp`'.green].join('');  
+    var gulpMessage = ['You have specified Ionic CLI to set up sass.'.red, '\n', 'However, you do not have Gulp installed globally. Please run '.red, '`npm install -g gulp`'.green].join('');
     logging.logger.info(gulpMessage);
     return Q(gulpMessage);
   }
@@ -109,7 +109,7 @@ Setup.sassSetup = function sassSetup(appDirectory) {
   .then(q.resolve)
   .catch(function(ex) {
     q.reject(ex);
-    return Utils.fail('Exception with ')
+    return Utils.fail('Exception with ');
   });
 
   return q.promise;
@@ -220,14 +220,14 @@ Setup.checkPreReqs = function checkPreReqs() {
   }
 
   return hasPreReqs;
-}
+};
 
 Setup.setupFacebook = function setupFacebook(appDirectory) {
   var facebookAppUrl = 'https://developers.facebook.com/apps/';
   var installMessage = ['The Facebook plugin will be setup.\nYou will now be prompted for your App ID and Name.\nGet these settings from:', facebookAppUrl].join(' ');
   logging.logger.info(installMessage.blue.bold);
   //This wont work by downloading a release.
-  //We will need to git clone it some how- 
+  //We will need to git clone it some how-
   //http://stackoverflow.com/questions/24626729/facebooksdk-facebooksdk-h-file-not-found
   var downloadUrl = 'https://github.com/Wizcorp/phonegap-facebook-plugin/archive/master.zip';
   var zipOutPath = path.join(appDirectory, 'base');
@@ -236,7 +236,7 @@ Setup.setupFacebook = function setupFacebook(appDirectory) {
   var promise;
 
   if (!Setup.checkPreReqs()) {
-    logging.logger.error('prereq check fail')
+    logging.logger.error('prereq check fail');
     promise = Setup.promptForPlatformInstall();
   } else {
     promise = Q();
@@ -268,12 +268,12 @@ Setup.installFacebookPlugin = function installFacebookPlugin(appDirectory, faceb
   var result = shelljs.exec(command);
   logging.logger.info('Running: ', command);
 
-  if (result.code != 0) {
+  if (result.code !== 0) {
     var errorMessage = ['There was an error adding the Cordova Facebook Plugin', result.output].join('\n');
     Utils.fail(errorMessage);
     throw new Error(errorMessage);
   } else {
-    logging.logger.info('\nAdded Cordova Facebook Plugin')
+    logging.logger.info('\nAdded Cordova Facebook Plugin');
   }
   // return q.promise;
 };
@@ -284,7 +284,7 @@ Setup.showMarkup = function showMarkup() {
   logging.logger.info('Put this JS in your Controller to use the Facebook plugin:'.green);
   logging.logger.info(facebookSnippet.blue);
   logging.logger.info('Use this HTML to trigger the above login method'.green);
-  logging.logger.info('<button ng-click="login()">Login to Facebook!</button>'.blue)
+  logging.logger.info('<button ng-click="login()">Login to Facebook!</button>'.blue);
 };
 
 Setup.promptForPlatformInstall = function promptForPlatformInstall() {
@@ -330,7 +330,7 @@ Setup.promptForFacebookInfo = function promptForFacebookInfo() {
     var fbInfo = {
       app_id: result.app_id,
       app_name: result.app_name
-    }
+    };
     return fbInfo;
   });
 };
@@ -376,7 +376,7 @@ Setup.downloadZipToDir = function downloadZipToDir(downloadUrl, zipOutPath, outp
   }, function(error) {
     logging.logger.info('Failed to download Facebook plugin - ', error);
     q.reject();
-  })
+  });
 
   return q.promise;
 };

--- a/lib/share.js
+++ b/lib/share.js
@@ -43,8 +43,8 @@ Share.shareApp = function shareApp(appDirectory, jar, email) {
         return q.reject('Error sharing: ' + err);
       }
       logging.logger.info('An invite to view your app was sent.'.green);
-      return q.resolve('An invite to view your app was sent.')
-    })
+      return q.resolve('An invite to view your app was sent.');
+    });
   });
 
   return q.promise;

--- a/lib/start.js
+++ b/lib/start.js
@@ -161,7 +161,7 @@ Start.fetchWrapper = function fetchWrapper(options) {
   });
 
   return q.promise;
-}
+};
 
 //Tested
 Start.fetchSeed = function(options) {
@@ -459,10 +459,10 @@ Start.fetchLocalStarter = function(options) {
 Start.fetchIonicStarter = function(options) {
 
   // Get the starter project repo name:
-  var repoName = ['ionic-starter-', options.template].join('')
+  var repoName = ['ionic-starter-', options.template].join('');
 
   // Get the URL for the starter project repo:
-  var repoUrl = ['https://github.com/driftyco/', repoName].join('')
+  var repoUrl = ['https://github.com/driftyco/', repoName].join('');
 
   return Start.fetchGithubStarter(options, repoUrl);
 };
@@ -580,13 +580,13 @@ Start.fetchPlnkr = function fetchPlnkr(options) {
     plnkrId = plnkrSplit[plnkrSplit.length - 1];
 
     if(plnkrId.indexOf('.zip') != -1) {
-      plnkrId = plnkrId.replace('.zip', '')
+      plnkrId = plnkrId.replace('.zip', '');
     }
   }
 
   plnkrUrl = ['http://api.plnkr.co/plunks/', plnkrId, '.zip'].join('');
 
-  logging.logger.info('\nDownloading Plnkr url:', plnkrUrl)
+  logging.logger.info('\nDownloading Plnkr url:', plnkrUrl);
 
   var extractPath = path.join(options.targetPath, 'plnkr');
 
@@ -603,7 +603,7 @@ Start.fetchPlnkr = function fetchPlnkr(options) {
     } catch(e) {
       q.reject(e);
     }
-  })
+  });
 
   return q.promise;
 };
@@ -647,7 +647,7 @@ Start.initCordovaFromGui = function initCordovaFromGui(options, appSetup) {
       .catch(function(ex) {
         q.reject(ex);
         throw ex;
-      })
+      });
       q.resolve();
 
     } else {
@@ -781,8 +781,8 @@ Start.updateConfigXml = function(targetPath, packageName, appName, ios, android)
 
   } catch(e) {
     // return self.ionic.fail('Error updating config.xml file: ' + e);
-    logging.logger.error('Error updating config.xml file: %s', e, {})
-    return
+    logging.logger.error('Error updating config.xml file: %s', e, {});
+    return;
   }
 };
 
@@ -791,7 +791,7 @@ Start.setupSass = function(options) {
   if(options.setupSass) {
     // auto setup sass if they set the option
     // logging.logger.info('setup sass');
-    var IonicSetupTask = require('./setup').IonicTask
+    var IonicSetupTask = require('./setup').IonicTask;
     var setupTask = new IonicSetupTask();
     hasSass = true;
     return setupTask.sassSetup();

--- a/lib/state.js
+++ b/lib/state.js
@@ -95,7 +95,7 @@ State.platformExists = function platformExists(appDirectory, platform) {
   } catch (ex) {
   }
   return platformExists;
-}
+};
 
 State.saveExistingPlatforms = function saveExistingPlatforms(appDirectory, packageJson) {
   var pp = path.join(appDirectory, 'platforms'),
@@ -118,7 +118,7 @@ State.saveExistingPlatforms = function saveExistingPlatforms(appDirectory, packa
     platformPath = path.join(appDirectory, 'platforms', platform);
     platformStats = fs.statSync(platformPath);
     if (!platformStats.isDirectory()) {
-      return
+      return;
     }
 
     try {
@@ -211,7 +211,7 @@ State.saveExistingPlugins = function saveExistingPlugins(appDirectory, packageJs
       }
 
       pluginXmlPath = path.join(appDirectory, 'plugins', pluginId, 'plugin.xml');
-      pluginXml = State.getXmlData(pluginXmlPath)
+      pluginXml = State.getXmlData(pluginXmlPath);
 
       pluginName = pluginXml.plugin.name;
 
@@ -227,7 +227,7 @@ State.saveExistingPlugins = function saveExistingPlugins(appDirectory, packageJs
           // logging.logger.info('looking at preference: ', preference)
         });
       }
-     
+
       keyValueList = {};
 
       if (hasVariables) {
@@ -235,9 +235,9 @@ State.saveExistingPlugins = function saveExistingPlugins(appDirectory, packageJs
         // var features = configXmlData.widget.feature;
         // events.emit('log', 'features', features)
         var pluginPreferences = State.getPluginPreferences(fetchJson, pluginId);
-        
-          
-        // why we are searching for plugin params from the config xml?  
+
+
+        // why we are searching for plugin params from the config xml?
         //featureParams = State.getPluginParameters(configXmlData, pluginName);
         // features.forEach(function(potFeature) {
         //   if(potFeature.$.name == pluginName) {
@@ -303,10 +303,10 @@ State.getXmlData = function getXmlData(xmlPath) {
 
 State.getPlatformVersion = function getPlatformVersion(path) {
   var result = shelljs.exec(['node', path].join(' '), { silent: true });
-  if (result.code != 0) {
+  if (result.code !== 0) {
     return '';
   }
-  var version = result.output
+  var version = result.output;
   // logging.logger.info('Version for path:', path, version)
   return version.replace(/\n/g, '');
 };
@@ -403,7 +403,7 @@ State.savePackageJson = function savePackageJson(appDirectory, packageJsonData) 
     var packageJsonPath = path.join(appDirectory, 'package.json');
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJsonData, null, 2) + "\n");
   } catch (e) {
-    logging.logger.error(('Error saving ' + packageJsonPath + ': %s').bold, e, {});
+    logging.logger.error(('Error saving ' + appDirectory + 'package.json' + ': %s').bold, e, {});
   }
 };
 
@@ -427,7 +427,7 @@ State.restoreState = function restoreState(appDirectory, options) {
   var restorePromise;
 
   if (options.platforms) {
-    logging.logger.info('Restoring Platforms\n'.blue.bold)
+    logging.logger.info('Restoring Platforms\n'.blue.bold);
 
     restorePromise = State.restorePlatforms(appDirectory, packageJson)
     .then(function() {
@@ -441,7 +441,7 @@ State.restoreState = function restoreState(appDirectory, options) {
   return restorePromise
   .then(function() {
     if (options.plugins) {
-      logging.logger.info('\rRestoring Plugins\n'.blue.bold)
+      logging.logger.info('\rRestoring Plugins\n'.blue.bold);
       return State.restorePlugins(appDirectory, packageJson)
       .then(function(){
         logging.logger.info('Restore plugins is complete\n'.green.bold);
@@ -451,10 +451,10 @@ State.restoreState = function restoreState(appDirectory, options) {
     }
   })
   .then(function() {
-    logging.logger.info('Ionic state restore completed\n'.blue.bold)
+    logging.logger.info('Ionic state restore completed\n'.blue.bold);
   })
   .catch(function(ex) {
-    logging.logger.error('Ionic state restore failed\n'.red.bold)
+    logging.logger.error('Ionic state restore failed\n'.red.bold);
     logging.logger.error(ex);
   });
 };
@@ -478,7 +478,7 @@ State.restorePlatforms = function restorePlatforms(appDirectory, packageJson) {
 State.processPlatform = function processPlatform(appDirectory, index, packageJson, promise) {
   if (index >= packageJson.cordovaPlatforms.length) {
     promise.resolve();
-    return
+    return;
   }
 
   try {
@@ -487,7 +487,7 @@ State.processPlatform = function processPlatform(appDirectory, index, packageJso
     var platformCommand;
 
     if (typeof platform == 'string') {
-      platformCommand = ['cordova platform add ', platform].join('')
+      platformCommand = ['cordova platform add ', platform].join('');
     } else {
       //Here, they have either a special version, or locator for
       //local install or github install
@@ -499,16 +499,17 @@ State.processPlatform = function processPlatform(appDirectory, index, packageJso
         State.processPlatform(appDirectory, index + 1, packageJson, promise);
     });
   } catch (ex) {
-    logging.logger.error('An error happened processing the previous cordova plugins')
-    logging.logger.error(ex)
-    promise.reject(ex)
+    logging.logger.error('An error happened processing the previous cordova plugins');
+    logging.logger.error(ex);
+    promise.reject(ex);
   }
 };
 
 State.createAddRemoveStatement = function createAddRemoveStatement(plugin) {
     // logging.logger.info('Creating add/remove statement', plugin)
+    var pluginCmd;
     try {
-      var pluginCmd = 'cordova plugin add ';
+      pluginCmd = 'cordova plugin add ';
       if (typeof plugin === 'string') {
         pluginCmd += plugin;
       } else {
@@ -520,7 +521,7 @@ State.createAddRemoveStatement = function createAddRemoveStatement(plugin) {
         }
       }
     } catch (ex) {
-      logging.logger.error('Failed to create add plugin statement: %s', ex, {})
+      logging.logger.error('Failed to create add plugin statement: %s', ex, {});
     }
 
     // logging.logger.info('plugin cmd', pluginCmd)
@@ -531,7 +532,7 @@ State.createAddRemoveStatement = function createAddRemoveStatement(plugin) {
 State.processPlugin = function processPlugin(appDirectory, index, packageJson, promise) {
   if (index >= packageJson.cordovaPlugins.length) {
     promise.resolve();
-    return
+    return;
   }
   try {
     // logging.logger.info('processing plugin', index, packageJson)
@@ -539,15 +540,15 @@ State.processPlugin = function processPlugin(appDirectory, index, packageJson, p
     var pluginCommand = State.createAddRemoveStatement(plugin);
     logging.logger.info(pluginCommand);
     shelljs.exec(pluginCommand, {async: true}, function(code, output) {
-      if (code != 0) {
+      if (code !== 0) {
         throw 'Error executing "' + pluginCommand + '":\n' + output;
       }
-      State.processPlugin(appDirectory, index + 1, packageJson, promise)
+      State.processPlugin(appDirectory, index + 1, packageJson, promise);
     });
   } catch (ex) {
-    logging.logger.error('An error happened processing the previous cordova plugins')
-    logging.logger.error(ex)
-    promise.reject(ex)
+    logging.logger.error('An error happened processing the previous cordova plugins');
+    logging.logger.error(ex);
+    promise.reject(ex);
   }
 };
 
@@ -601,14 +602,14 @@ State.getPluginPreferences = function getPluginPreferences(fetchJson, pluginName
     if(!fetchJson || !fetchJson[pluginName]){
         throw 'Invalid fetch.json Data';
     }
-    
+
     var preferences = fetchJson[pluginName].variables;
     if(Object.keys(preferences).length !== 0){
         return preferences;
     }
-    
+
     return null;
-    
+
 };
 
 //
@@ -650,12 +651,12 @@ State.savePlugin = function savePlugin(appDirectory, pluginId, variables) {
             pluginInfo.variables[splits[0]] = splits[1];
         }
     }
-    
+
   // pluginId could be org.ionic.keyboard or ./engine/facebook-plugin
   if (pluginId.indexOf('/') === -1) { //its just an id
-    
+
     //Check and save for variables
-    if(!variables){ 
+    if(!variables){
       State.addOrUpdatePluginToPackageJson(packageJson, pluginId);
     }
     else{
@@ -663,7 +664,7 @@ State.savePlugin = function savePlugin(appDirectory, pluginId, variables) {
       pluginInfo.id = pluginId = State.getPluginFromFetchJsonByLocator(appDirectory, pluginInfo.locator);
       State.addOrUpdatePluginToPackageJson(packageJson, pluginId, pluginInfo);
     }
-    
+
     return State.savePackageJson(appDirectory, packageJson);
   }
 
@@ -804,7 +805,7 @@ State.resetState = function resetState(appDirectory, options) {
   State.restoreState(appDirectory, options)
   .then(function() {
     logging.logger.info('Ionic reset state complete'.green.bold);
-  })
+  });
 };
 
 State.clearState = function clearState(appDirectory) {

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,5 +1,5 @@
 var Buffer = require('buffer').Buffer,
-    http = require('http'), 
+    http = require('http'),
     IonicConfig = require('./config'),
     path = require('path'),
     util = require('util'),
@@ -647,7 +647,7 @@ Stats.createId = function createId() {
 
   ionicConfig.set('ank', uuid);
   return uuid;
-}
+};
 
 Stats.getUniqueId = function getUniqueId() {
   var uid = ionicConfig.get('ank');

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -31,8 +31,8 @@ IonicTask.prototype.fetchStarterTemplates = function() {
       try {
         templatesJson = JSON.parse(html);
       }catch(ex) {
-        logging.logger.error('Error: ', ex)
-        q.reject('Error occured in download templates:', ex)
+        logging.logger.error('Error: ', ex);
+        q.reject('Error occured in download templates:', ex);
         self.ionic.fail(ex);
         return;
       }
@@ -47,17 +47,17 @@ IonicTask.prototype.fetchStarterTemplates = function() {
 
 IonicTask.prototype.list = function list(templates) {
   //Should have array of [{ name: 'name', description: 'desc' }]
-  logging.logger.info('\n')
+  logging.logger.info('\n');
   _.each(templates, function(template) {
     var rightColumn = 20, dots = '';
     var shortName = template.name.replace('ionic-starter-', '');
     while( (shortName + dots).length < rightColumn + 1) {
       dots += '.';
     }
-    var outStr = []
+    var outStr = [];
     logging.logger.info(shortName.green, dots, template.description);
-  })
-}
+  });
+};
 
 IonicTask.prototype.run = function(ionic) {
   var self = this;
@@ -65,12 +65,12 @@ IonicTask.prototype.run = function(ionic) {
   self.fetchStarterTemplates()
   .then(function(starterTemplates) {
     self.list(starterTemplates.items);
-  })
+  });
 
   var templates = _.sortBy(starterTemplates.items, function(template){ return template.name; });
   logging.logger.info('Ionic Starter templates'.green);
   this.list(templates);
 
-}
+};
 
 exports.IonicTask = IonicTask;

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -219,7 +219,7 @@ Upload.deploy = function deploy(project, jar, deploy) {
       if (error || response.statusCode != 200) {
         q.reject("Deploy failed: " +  (error || response.statusCode));
       } else {
-        logging.logger.info('Deploy Successful!'.green.bold)
+        logging.logger.info('Deploy Successful!'.green.bold);
         q.resolve(true);
       }
     });
@@ -303,7 +303,7 @@ Upload.getDirectUploadKey = function getDirectUploadKey(project, jar, note) {
 
       if (response.statusCode != 200 ) {
 
-        var errorMessage = jsonData ? jsonData['errors'] : 'Unknown error';
+        var errorMessage = jsonData ? jsonData.errors : 'Unknown error';
         return q.reject(['An error occurred uploading your application - ', errorMessage].join(''));
       }
 
@@ -336,13 +336,13 @@ Upload.addCacheBusters = function addCacheBusters(indexPath) {
     $('script').each(function(i, el){
       if (typeof el.attribs.src === "undefined") return true; //continue
       urlObj = url.parse(el.attribs.src, true);
-      urlObj.query['ionicCachebuster'] = randomString;
+      urlObj.query.ionicCachebuster = randomString;
       el.attribs.src = url.format(urlObj);
     });
     $('link').each(function(i, el){
       if (typeof el.attribs.href === "undefined") return true; //continue
       urlObj = url.parse(el.attribs.href, true);
-      urlObj.query['ionicCachebuster'] = randomString;
+      urlObj.query.ionicCachebuster = randomString;
       el.attribs.href = url.format(urlObj);
     });
 
@@ -381,16 +381,16 @@ Upload.removeCacheBusters = function removeCacheBusters(indexPath) {
       urlObj = url.parse(el.attribs.src, true);
 
       //Fix for: https://github.com/driftyco/ionic-cli/issues/504
-      if (!urlObj.query['ionicCachebuster']) return true;
+      if (!urlObj.query.ionicCachebuster) return true;
 
-      delete urlObj.query['ionicCachebuster'];
+      delete urlObj.query.ionicCachebuster;
       delete urlObj.search; // or url.format will ignore modified `query`
       el.attribs.src = url.format(urlObj);
     });
     $('link').each(function(i, el){
       if (typeof el.attribs.href === "undefined") return true; //continue
       urlObj = url.parse(el.attribs.href, true);
-      delete urlObj.query['ionicCachebuster'];
+      delete urlObj.query.ionicCachebuster;
       delete urlObj.search; // or url.format will ignore modified `query`
       el.attribs.href = url.format(urlObj);
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,15 +17,15 @@ Utils.errorHandler = null;
 
 Utils.transformCookies = function transformCookies(jar) {
   if(!jar) {
-    throw new Error('You parse out cookies if they are null')
+    throw new Error('You parse out cookies if they are null');
   }
   return jar.map(function(c) {
     return c.key + "=" + encodeURIComponent(c.value);
   }).join("; ");
-}
+};
 
 Utils.retrieveCsrfToken = function retrieveCsrfToken(jar) {
-  if(!jar || typeof jar == 'undefined' || jar.length == 0) {
+  if(!jar || typeof jar === 'undefined' || jar.length === 0) {
     return '';
   }
   var csrftoken = '';
@@ -36,7 +36,7 @@ Utils.retrieveCsrfToken = function retrieveCsrfToken(jar) {
     }
   }
   return csrftoken;
-}
+};
 
 /**
  * Utils.createArchive will zip up a subdirectory in the app directory
@@ -59,7 +59,7 @@ Utils.createArchive = function(appDirectory, documentRoot) {
     q.reject(documentRoot + ' directory cannot be found. Make sure the working directory is at the top level of an Ionic project.', 'upload');
   }
 
-  var zipDestination = zipPath + ".zip"
+  var zipDestination = zipPath + '.zip';
   var zip = fs.createWriteStream(zipDestination);
 
   var archive = archiver('zip');
@@ -164,7 +164,7 @@ Utils.fetchArchive = function fetchArchive(targetPath, archiveUrl, isGui) {
   });
 
   return q.promise;
-}
+};
 
 Utils.preprocessOptions = function preprocessOptions(options) {
   var result = {};
@@ -264,7 +264,7 @@ Utils.getContentSrc = function getContentSrc(appDirectory) {
   } catch(e) {
     logging.logger.debug('Utils.getContentSrc failed', e);
     console.log(e.stack);
-    return Utils.fail('Error loading ' + configXmlPath + ': ' + e);
+    return Utils.fail('Error loading ' + appDirectory + 'config.xml' + ': ' + e);
   }
 
   return contentSrc;
@@ -272,10 +272,11 @@ Utils.getContentSrc = function getContentSrc(appDirectory) {
 
 Utils.mergeOptions = function mergeOptions(obj1, obj2) {
     var obj3 = {};
-    for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; }
-    for (var attrname in obj2) { obj3[attrname] = obj2[attrname]; }
+    var attrname;
+    for (attrname in obj1) { obj3[attrname] = obj1[attrname]; }
+    for (attrname in obj2) { obj3[attrname] = obj2[attrname]; }
     return obj3;
-}
+};
 
 Utils.fail = function fail(msg, taskHelp) {
   try {
@@ -295,13 +296,13 @@ Utils.fail = function fail(msg, taskHelp) {
   } catch (ex) {
     logging.logger.debug('Utils.fail: ', ex);
   }
-}
+};
 
 Utils.gulpInstalledGlobally = function gulpInstalledGlobally() {
   var result = shelljs.exec('gulp -v', { silent: true });
 
-  if(result.code != 0) {
+  if(result.code !== 0) {
     return false;
   }
   return true;
-}
+};

--- a/spec/browser.spec.js
+++ b/spec/browser.spec.js
@@ -15,7 +15,7 @@ var setCordovaVersion = function setCordovaVersion(version) {
       cordova: version
     };
     spyOn(info, 'gatherInfo').andReturn(fakeInfo);
-  }
+  };
 };
 
 describe('Browser', function() {
@@ -24,7 +24,7 @@ describe('Browser', function() {
 
   beforeEach(function() {
     spyOn(Browser, 'saveBrowserInstallation');
-  })
+  });
 
   it('should have Browser defined', function() {
     expect(Browser).toBeDefined();
@@ -35,7 +35,7 @@ describe('Browser', function() {
     it('should fail with no parameters passed', function() {
       expect(function() {
         Browser.addBrowser();
-      }).toThrow('You must pass a directory to run this command')
+      }).toThrow('You must pass a directory to run this command');
     });
 
     it('should fail with no browser passed', function() {
@@ -54,7 +54,7 @@ describe('Browser', function() {
         expect(Browser.installCrosswalk).toHaveBeenCalledWith(testDirectory, Browser.defaultCrosswalkVersion, true);
       })
       .catch(function(ex){
-        console.log(ex)
+        console.log(ex);
         console.log(ex.stack);
         expect('this').toBe('not this');
       })
@@ -72,7 +72,7 @@ describe('Browser', function() {
         expect(Browser.installCrosswalk).toHaveBeenCalledWith(testDirectory, Browser.defaultCrosswalkVersion, saveToPackageJson);
       })
       .catch(function(ex){
-        console.log(ex)
+        console.log(ex);
         console.log(ex.stack);
         expect('this').toBe('not this');
       })
@@ -103,10 +103,10 @@ describe('Browser', function() {
       beforeEach(setCordovaVersion('4.3.0'));
 
       it('should call the appropriate methods to install crosswalk', function(done) {
-        
+
         spyOn(Browser, 'downloadFiles').andReturn(Q());
         var methods = [
-          'removeAndroidProject', 
+          'removeAndroidProject',
           'removeCrosswalkEngines',
           'addCordova40xProject',
           'addCrosswalkPlugin',
@@ -115,7 +115,7 @@ describe('Browser', function() {
           // 'addGradleProperties',
         ];
         var saveToPackageJson = true;
-        
+
         methods.forEach(function(method) {
           spyOn(Browser, method);
         });
@@ -128,11 +128,11 @@ describe('Browser', function() {
           // expect(Browser.downloadFiles).toHaveBeenCalledWith(testDirectory, Browser.defaultCrosswalkVersion);
           methods.forEach(function(method) {
             expect(Browser[method]).toHaveBeenCalledWith(testDirectory, saveToPackageJson);
-          })
+          });
         })
         .catch(function(ex){
           console.log(ex);
-          console.log(ex.stack)
+          console.log(ex.stack);
           expect('this').toBe('not this');
         })
         .fin(done);
@@ -177,7 +177,7 @@ describe('Browser', function() {
         expect(Browser.downloadCrosswalkWebviews).toHaveBeenCalledWith(testDirectory, Browser.defaultCrosswalkVersion, false);
       })
       .catch(function(error) {
-        console.log('error', error, error.stack)
+        console.log('error', error, error.stack);
         expect('this').toBe('not this');
       })
       .fin(done);

--- a/spec/config-xml.spec.js
+++ b/spec/config-xml.spec.js
@@ -91,6 +91,6 @@ describe('ConfigXml', function() {
       })
       .fin(done);
     });
-  })
+  });
 
 });

--- a/spec/cordova.spec.js
+++ b/spec/cordova.spec.js
@@ -19,7 +19,7 @@ describe('Cordova', function() {
   describe('#removePlatform', function() {
     it('should call cordova.platform when removePlatform is called', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.removePlatform(testDirectory, 'ios');
       })
@@ -35,7 +35,7 @@ describe('Cordova', function() {
     it('should call state.removePlatform when removePlatform is called to save platform', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
       spyOn(state, 'removePlatform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.removePlatform(testDirectory, 'ios', true);
       })
@@ -51,7 +51,7 @@ describe('Cordova', function() {
     it('should not call state.savePlatform when removePlatform is called to save platform', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
       spyOn(state, 'removePlatform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.removePlatform(testDirectory, 'ios');
       })
@@ -68,7 +68,7 @@ describe('Cordova', function() {
   describe('#addPlugin', function() {
     it('should call cordova.plugin when addPlugin is called', function(done) {
       spyOn(cordova, 'plugin').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlugin(testDirectory, testPluginId);
       })
@@ -85,7 +85,7 @@ describe('Cordova', function() {
     it('should not call state.savePlugin when addPlugin is not called to save plugin', function(done) {
       spyOn(cordova, 'plugin').andReturn(Q());
       spyOn(state, 'savePlugin').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlugin(testDirectory, 'org.apache.cordova.device');
       })
@@ -101,7 +101,7 @@ describe('Cordova', function() {
     it('should call state.savePlugin when addPlugin is called to save plugin', function(done) {
       spyOn(cordova, 'plugin').andReturn(Q());
       spyOn(state, 'savePlugin').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlugin(testDirectory, 'org.apache.cordova.device', null, true);
       })
@@ -118,7 +118,7 @@ describe('Cordova', function() {
   describe('#removePlugin', function() {
     it('should call cordova.plugin when removePlugin is called', function(done) {
       spyOn(cordova, 'plugin').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.removePlugin(testDirectory, testPluginId);
       })
@@ -137,7 +137,7 @@ describe('Cordova', function() {
   describe('#runPlatform', function() {
     it('should call cordova.run when runPlatform is called', function(done) {
       spyOn(cordova, 'run').andReturn(Q());
-      
+
       var options = {
         platforms: ['ios'],
         options: [],
@@ -147,7 +147,7 @@ describe('Cordova', function() {
         stdio: 'pipe'
       };
 
-      Q()    
+      Q()
       .then(function() {
         return Cordova.runPlatform(testDirectory, 'ios');
       })
@@ -165,7 +165,7 @@ describe('Cordova', function() {
   describe('#addPlatform', function() {
     it('should call cordova.platform when addPlatform is called', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlatform(testDirectory, 'ios');
       })
@@ -181,7 +181,7 @@ describe('Cordova', function() {
     it('should call state.savePlatform when addPlatform is called with save platform', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
       spyOn(state, 'savePlatform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlatform(testDirectory, 'ios', true);
       })
@@ -197,7 +197,7 @@ describe('Cordova', function() {
     it('should not call state.savePlatform when addPlatform is called without save platform', function(done) {
       spyOn(cordova, 'platform').andReturn(Q());
       spyOn(state, 'savePlatform').andReturn(Q());
-      Q()    
+      Q()
       .then(function() {
         return Cordova.addPlatform(testDirectory, 'ios');
       })
@@ -209,6 +209,6 @@ describe('Cordova', function() {
       })
       .fin(done);
     });
-  }); 
+  });
 
 });

--- a/spec/hooks.spec.js
+++ b/spec/hooks.spec.js
@@ -26,6 +26,6 @@ describe('Hooks', function() {
 
   //   shelljs.rm('rf', appPath);
 
-  // });  
+  // });
 
 });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -13,11 +13,11 @@ describe('index', function() {
     });
   }
 
-  var objs = ['browser', 'configXml', 'cordova', 'events', 'hooks', 'info', 
-              'ioConfig', 'login', 'logging', 'multibar', 'opbeat', 'project', 
-              'share', 'semver', 'serve', 'settings', 'setup', 'start', 'state', 
+  var objs = ['browser', 'configXml', 'cordova', 'events', 'hooks', 'info',
+              'ioConfig', 'login', 'logging', 'multibar', 'opbeat', 'project',
+              'share', 'semver', 'serve', 'settings', 'setup', 'start', 'state',
               'stats', 'upload', 'utils'];
-  // Doing it this way to give better failure messages. 
+  // Doing it this way to give better failure messages.
   // Ensures all commands are available currently from
   objs.forEach(function(obj) {
     // expect(index[obj], obj).toBeDefined();

--- a/spec/info.spec.js
+++ b/spec/info.spec.js
@@ -22,9 +22,9 @@ describe('Info', function() {
     Info.gatherInfo();
 
     expect(Info.getIonicLibVersion).toHaveBeenCalled();
-    expect(Info.getNodeVersion).toHaveBeenCalled()
+    expect(Info.getNodeVersion).toHaveBeenCalled();
     expect(Info.getOsEnvironment).toHaveBeenCalled();
-    expect(Info.getCordovaInfo).toHaveBeenCalled();    
+    expect(Info.getCordovaInfo).toHaveBeenCalled();
   });
 
 });

--- a/spec/login.spec.js
+++ b/spec/login.spec.js
@@ -6,8 +6,8 @@ var Q = require('q'),
 
 logging.logger = helpers.testingLogger;
 
-var cookieJar = [ 
-  { 
+var cookieJar = [
+  {
     key: '__cfduid',
     value: 'cfduid',
     expires: '2016-05-28T16:24:12.000Z',
@@ -18,9 +18,9 @@ var cookieJar = [
     _creationRuntimeIdx: 1,
     _initialCreationTime: 1432916656691,
     hostOnly: false,
-    lastAccessed: '2015-05-29T16:24:16.704Z' 
+    lastAccessed: '2015-05-29T16:24:16.704Z'
   },
-  { 
+  {
     key: 'csrftoken',
     value: 'csrftoken',
     domain: 'ionic.io',
@@ -31,9 +31,9 @@ var cookieJar = [
     _creationRuntimeIdx: 2,
     _initialCreationTime: 1432916656692,
     hostOnly: false,
-    lastAccessed: '2015-05-29T16:24:16.704Z' 
+    lastAccessed: '2015-05-29T16:24:16.704Z'
   },
-  { 
+  {
     key: 'sessionid',
     value: 'sesshionid',
     domain: 'ionic.io',
@@ -45,7 +45,7 @@ var cookieJar = [
     _creationRuntimeIdx: 3,
     _initialCreationTime: 1432916656692,
     hostOnly: false,
-    lastAccessed: '2015-05-29T16:24:16.704Z' 
+    lastAccessed: '2015-05-29T16:24:16.704Z'
   }
 ];
 

--- a/spec/project.spec.js
+++ b/spec/project.spec.js
@@ -20,7 +20,7 @@ describe('Project', function() {
 
   beforeEach(function() {
     spyOnFileSystem(data);
-  });  
+  });
 
   it('should have Project defined', function() {
     expect(Project).toBeDefined();

--- a/spec/release.js
+++ b/spec/release.js
@@ -11,7 +11,7 @@ Release.start = function start(appDirectory) {
     dest: './www/dist/index.html',
     removeLivereload: true,
     _ : ['./www/index.html']
-  }
+  };
 
   var content = fs.readFileSync(filePath).toString();
   var blocks = useminLib.getBlocks(argv._[0], content, argv.removeLivereload);
@@ -21,4 +21,3 @@ Release.start = function start(appDirectory) {
   // console.log('output', output);
 
 };
-

--- a/spec/serve.spec.js
+++ b/spec/serve.spec.js
@@ -1,6 +1,6 @@
 var Q = require('q'),
     events = require('../lib/events'),
-    helpers = require('./helpers')
+    helpers = require('./helpers'),
     Project = require('../lib/project'),
     rewire = require('rewire'),
     logging = require('../lib/logging');
@@ -107,7 +107,7 @@ describe('Serve', function() {
 
   describe('#runLivereload', function() {
     it('should run environment live reload port over options livereload port', function(done) {
-      
+
       var vfsSpy = createSpyObj('vfs', ['watch']);
       Serve.__set__('vfs', vfsSpy);
 
@@ -115,9 +115,9 @@ describe('Serve', function() {
       lrServerSpy.listen = function(){}; //hack to add spy
       spyOn(lrServerSpy, 'listen').andCallFake(function(port, cb) {
         cb();
-      })
+      });
       var tinylrSpy = createSpy('tinylr').andReturn(lrServerSpy);
-      
+
       Serve.__set__('tinylr', tinylrSpy);
       var lrSpy = createSpy('lr').andReturn({});
       var th = Serve.__set__('lr', lrSpy);

--- a/spec/setup.spec.js
+++ b/spec/setup.spec.js
@@ -16,7 +16,7 @@ describe('Setup', function() {
     spyOn(setup, 'npmInstall').andReturn(Q());
     spyOn(setup, 'modifyIndexFile').andReturn(Q());
     spyOn(setup, 'buildSass').andReturn(Q());
-    
+
     Q()
     .then(function(){
       return setup.sassSetup(testDir);

--- a/spec/start.spec.js
+++ b/spec/start.spec.js
@@ -13,12 +13,12 @@ logging.logger = helpers.testingLogger;
 
 var tmpDir = helpers.tmpDir('create_test');
 
-// Things to test 
-// Does it allow invalid vars? 
+// Things to test
+// Does it allow invalid vars?
 // What if a path doesnt exist?
 // Invalid ID?
 var dummyPath = '/Users/Test/Development/Ionic',
-    dummyPackageName = 'com.ionic.app', 
+    dummyPackageName = 'com.ionic.app',
     dummyAppName = 'Ionic App',
     appSetup;
 
@@ -29,17 +29,17 @@ var dummyOptions = {
   appName: dummyAppName,
   isCordovaProject: true,
   setupSass: true
-}
+};
 
 describe('Start', function() {
 
   it('should have methods defined', function(){
-    var methods = ['startApp', 'fetchWrapper', 'fetchSeed', 'loadAppSetup', 'fetchCreatorApp', 
-      'fetchCodepen', 'convertTemplates', 'fetchLocalStarter', 'fetchIonicStarter', 
+    var methods = ['startApp', 'fetchWrapper', 'fetchSeed', 'loadAppSetup', 'fetchCreatorApp',
+      'fetchCodepen', 'convertTemplates', 'fetchLocalStarter', 'fetchIonicStarter',
       'fetchGithubStarter', 'initCordova', 'updateConfigXml', 'setupSass', 'updateLibFiles', 'finalize'];
     methods.forEach(function(method) {
       expect(start[method]).toBeDefined();
-    })
+    });
   });
 
   it('should have fetchWrapper defined', function() {
@@ -77,30 +77,30 @@ describe('Start', function() {
       startAppFunctions.forEach(function(func) {
         spyOn(start, func).andReturn(Q());
       });
-    })
+    });
 
     it('should fail if no options are passed', function() {
       expect(function() {
-        start.startApp()
-      }).toThrow('You cannot start an app without options')
-    })
+        start.startApp();
+      }).toThrow('You cannot start an app without options');
+    });
 
     it('should fail if an invalid path is passed', function() {
       expect(function() {
-        start.startApp({targetPath: '.'})
-      }).toThrow('Invalid target path, you may not specify \'.\' as an app name')
-    })
+        start.startApp({targetPath: '.'});
+      }).toThrow('Invalid target path, you may not specify \'.\' as an app name');
+    });
 
     it('should call fetchWrapper', function(done) {
-      start.startApp(dummyOptions)
+      start.startApp(dummyOptions);
       expect(start.fetchWrapper).toHaveBeenCalledWith(dummyOptions);
-      done()
-    })
+      done();
+    });
 
     it('should call fetchSeed', function(done) {
       Q()
       .then(function(data) {
-        return start.startApp(dummyOptions)
+        return start.startApp(dummyOptions);
       })
       .then(function(data) {
         expect(start.fetchSeed).toHaveBeenCalledWith(dummyOptions);
@@ -109,12 +109,12 @@ describe('Start', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
 
     it('should call loadAppSetup', function(done) {
       Q()
       .then(function(data) {
-        return start.startApp(dummyOptions)
+        return start.startApp(dummyOptions);
       })
       .then(function(data) {
         expect(start.loadAppSetup).toHaveBeenCalledWith(dummyOptions);
@@ -123,7 +123,7 @@ describe('Start', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
 
     it('should call initCordova', function(done) {
       Q()
@@ -138,7 +138,7 @@ describe('Start', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
 
     it('should call setupSass', function(done) {
       Q()
@@ -153,7 +153,7 @@ describe('Start', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
 
     it('should call finalize', function(done) {
       Q()
@@ -168,8 +168,8 @@ describe('Start', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
-  })
+    });
+  });
 
   describe('#fetchWrapper', function(done) {
 
@@ -188,9 +188,9 @@ describe('Start', function() {
       expect(project.save).toHaveBeenCalledWith(dummyOptions.targetPath);
     });
 
-    it('should save app_id when passed in options', function() { 
+    it('should save app_id when passed in options', function() {
       var project = Project.wrap(Project.PROJECT_DEFAULT);
-      dummyOptions.ionicAppId = 'app-id'
+      dummyOptions.ionicAppId = 'app-id';
       spyOn(Project, 'create').andReturn(project);
       spyOn(project, 'set');
       spyOn(project, 'save');
@@ -208,7 +208,7 @@ describe('Start', function() {
 
       Q()
       .then(function() {
-        return start.fetchSeed(dummyOptions)
+        return start.fetchSeed(dummyOptions);
       })
       .then(function() {
         expect(start.fetchIonicStarter).toHaveBeenCalledWith(dummyOptions);
@@ -216,8 +216,8 @@ describe('Start', function() {
       .catch(function(data) {
         expect('this').toBe('not this' + data);
       })
-      .fin(done)
-    })
+      .fin(done);
+    });
 
     it('should call fetchCodepen when codepen URL is passed', function(done) {
       var codepenUrl = 'http://codepen.io/mhartington/pen/eomzw';
@@ -229,13 +229,13 @@ describe('Start', function() {
         return start.fetchSeed(dummyOptions);
       })
       .then(function() {
-        expect(start.fetchCodepen).toHaveBeenCalledWith(dummyOptions)
+        expect(start.fetchCodepen).toHaveBeenCalledWith(dummyOptions);
       })
       .catch(function(err) {
         expect('this').toBe('not this'+ err);
       })
-      .fin(done)
-    })
+      .fin(done);
+    });
 
     it('should call fetchCreatorApp when a creator url is passed', function(done) {
       var creatorUrl = 'http://app.ionic.io/creator:5010';
@@ -247,13 +247,13 @@ describe('Start', function() {
         return start.fetchSeed(dummyOptions);
       })
       .then(function() {
-        expect(start.fetchCreatorApp).toHaveBeenCalledWith(dummyOptions)
+        expect(start.fetchCreatorApp).toHaveBeenCalledWith(dummyOptions);
       })
       .catch(function(err) {
         expect('this').toBe('not this'+ err);
       })
-      .fin(done)
-    })
+      .fin(done);
+    });
 
     it('should call fetchGithubStarter when a github url is passed', function(done) {
       var githubUrl = 'http://github.com/driftyco/ionic-unit-test-starter';
@@ -265,13 +265,13 @@ describe('Start', function() {
         return start.fetchSeed(dummyOptions);
       })
       .then(function() {
-        expect(start.fetchGithubStarter).toHaveBeenCalledWith(dummyOptions, githubUrl)
+        expect(start.fetchGithubStarter).toHaveBeenCalledWith(dummyOptions, githubUrl);
       })
       .catch(function(err) {
         expect('this').toBe('not this'+ err);
       })
-      .fin(done)
-    })
+      .fin(done);
+    });
 
     it('should call fetchLocalStarter when a local path is passed', function(done) {
       var localPath = '/Users/Testing/Dev/local-starter';
@@ -283,13 +283,13 @@ describe('Start', function() {
         return start.fetchSeed(dummyOptions);
       })
       .then(function() {
-        expect(start.fetchLocalStarter).toHaveBeenCalledWith(dummyOptions)
+        expect(start.fetchLocalStarter).toHaveBeenCalledWith(dummyOptions);
       })
       .catch(function(err) {
         expect('this').toBe('not this'+ err);
       })
-      .fin(done)
-    })
+      .fin(done);
+    });
 
     it('should call fetchPlnkr when a plnkr url is passed', function(done) {
       var plnkrUrl = 'http://embed.plnkr.co/dFvL8n/preview';
@@ -301,7 +301,7 @@ describe('Start', function() {
         return start.fetchSeed(dummyOptions);
       })
       .then(function() {
-        expect(start.fetchPlnkr).toHaveBeenCalledWith(dummyOptions)
+        expect(start.fetchPlnkr).toHaveBeenCalledWith(dummyOptions);
       })
       .catch(function(err) {
         expect('this').toBe('not this'+ err);
@@ -341,7 +341,7 @@ describe('Start', function() {
     //   start.initCordova(dummyOptions, appSetup);
     //   expect(cordova.addPlatform).toHaveBeenCalledWith(dummyOptions.targetPath, 'android', true);
     // });
-  })
+  });
 
   describe('start end-to-end', function() {
     beforeEach(function() {
@@ -352,7 +352,7 @@ describe('Start', function() {
         process.chdir(path.join(__dirname, '..'));  // Needed to rm the dir on Windows.
         shell.rm('-rf', tmpDir);
     });
-    
-  })
 
-})
+  });
+
+});

--- a/spec/state.spec.js
+++ b/spec/state.spec.js
@@ -62,7 +62,7 @@ describe('State', function() {
     });
 
     it('should save ios and version with both are passed', function() {
-      var packageJson = 
+      var packageJson =
       spyOn(State, 'addOrUpdatePlatformToPackageJson').andCallFake(function(packageJson) {
         packageJson.cordovaPlatforms = [{ platform: 'ios', locator: 'ios@3.8.0', version: '3.8.0' }];
       });
@@ -179,7 +179,7 @@ describe('State', function() {
       spyOn(State, 'getPackageJson').andReturn(defaultPackageJson);
       spyOn(State, 'addOrUpdatePluginToPackageJson').andCallFake(function(packageJson) {
         packageJson.cordovaPlugins = [testPluginId];
-      })
+      });
       State.savePlugin(tempDirectory, testPluginId);
       expect(State.addOrUpdatePluginToPackageJson).toHaveBeenCalledWith(defaultPackageJson, testPluginId);
       expect(State.savePackageJson).toHaveBeenCalledWith(tempDirectory, defaultPackageJson);
@@ -192,7 +192,7 @@ describe('State', function() {
       spyOn(State, 'getPluginFromFetchJsonByLocator').andReturn('cordova-crosswalk-engine');
       spyOn(State, 'addOrUpdatePluginToPackageJson').andCallFake(function(packageJson) {
         packageJson.cordovaPlugins = [{locator: testLocalPluginId, id: 'cordova-crosswalk-engine'}];
-      })
+      });
       State.savePlugin(tempDirectory, testLocalPluginId);
       expect(State.addOrUpdatePluginToPackageJson).toHaveBeenCalledWith(defaultPackageJson, 'cordova-crosswalk-engine', {locator: testLocalPluginId, id: 'cordova-crosswalk-engine'});
       expect(State.savePackageJson).toHaveBeenCalledWith(tempDirectory, defaultPackageJson);
@@ -333,7 +333,7 @@ describe('State', function() {
       })
       .catch(function(ex) {
         expect('this').toBe('not this');
-        console.log(ex.stack)
+        console.log(ex.stack);
       })
       .fin(done);
     });
@@ -356,7 +356,7 @@ describe('State', function() {
       })
       .catch(function(ex) {
         expect('this').toBe('not this');
-        console.log(ex.stack)
+        console.log(ex.stack);
       })
       .fin(done);
     });
@@ -390,7 +390,7 @@ describe('State', function() {
         return State.restorePlugins(tempDirectory, defaultPackageJson);
       })
       .then(function() {
-        expect(State.processPlugin).toHaveBeenCalledWith(tempDirectory, 0, defaultPackageJson, promise);      
+        expect(State.processPlugin).toHaveBeenCalledWith(tempDirectory, 0, defaultPackageJson, promise);
       })
       .catch(function(ex) {
         console.log(ex.stack);
@@ -411,7 +411,7 @@ describe('State', function() {
         return State.restorePlatforms(tempDirectory, defaultPackageJson);
       })
       .then(function() {
-        expect(State.processPlatform).toHaveBeenCalledWith(tempDirectory, 0, defaultPackageJson, promise);      
+        expect(State.processPlatform).toHaveBeenCalledWith(tempDirectory, 0, defaultPackageJson, promise);
       })
       .catch(function(ex) {
         console.log(ex.stack);
@@ -439,7 +439,7 @@ describe('State', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
   });
 
   describe('#saveState', function (){
@@ -464,7 +464,7 @@ describe('State', function() {
         expect('this').toBe('not this');
       })
       .fin(done);
-    })
+    });
   });
 
   describe('#getPluginFromFetchJsonByLocator', function() {

--- a/spec/stats.spec.js
+++ b/spec/stats.spec.js
@@ -11,7 +11,7 @@ describe('Stats', function() {
 
   beforeEach(function() {
     Stats = rewire('../lib/stats');
-  })
+  });
 
   it('should have Stats defined', function() {
     // console.log(Stats);

--- a/spec/upload.spec.js
+++ b/spec/upload.spec.js
@@ -99,7 +99,7 @@ describe('Upload', function() {
         expect('this').toBe(ex.stack);
       })
       .fin(done);
-    })
+    });
   });
 
   describe('#removeCacheBusters', function() {
@@ -148,7 +148,7 @@ describe('Upload', function() {
         expect('this').toBe(ex.stack);
       })
       .fin(done);
-    })
+    });
   });
 
   describe('#doUpload', function() {

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -22,16 +22,16 @@ describe('Utils', function() {
     var methods = ['transformCookies', 'retrieveCsrfToken', 'createArchive', 'fetchArchive', 'preprocessOptions', 'getContentSrc', 'fail'];
     methods.forEach(function(method) {
       expect(Utils[method]).toBeDefined();
-    })
-  })
+    });
+  });
 
   describe('#transformCookies', function() {
     it('should check for valid cookie jar', function() {
       expect(function() {
         Utils.transformCookies(null);
-      }).toThrow('You parse out cookies if they are null')
-    })
-  })
+      }).toThrow('You parse out cookies if they are null');
+    });
+  });
 
   describe('#createArchive', function() {
     it('should zip the contents and resolve', function(done) {


### PR DESCRIPTION
Fix jshint errors:
- Missing semicolon
- Creating global variable
- Use '!==' to compare
- Variable is already defined
- ['app_id'] is better written in dot notation
- Bad escaping of EOL

Remove trailing whitespaces.