### PR TITLE
resources - splashscreen fixed for hdpi image in android

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -52,14 +52,14 @@ var Platforms = {
       images: [
         { name: 'drawable-land-ldpi-screen.png',    width: 320,   height: 240,   density: 'land-ldpi' },
         { name: 'drawable-land-mdpi-screen.png',    width: 480,   height: 320,   density: 'land-mdpi' },
-        { name: 'drawable-land-hdpi-screen.png',    width: 800,   height: 480,   density: 'land-hdpi' },
+        { name: 'drawable-land-hdpi-screen.png',    width: 960,   height: 640,   density: 'land-hdpi' },
         { name: 'drawable-land-xhdpi-screen.png',   width: 1280,  height: 720,   density: 'land-xhdpi' },
         { name: 'drawable-land-xxhdpi-screen.png',  width: 1600,  height: 960,   density: 'land-xxhdpi' },
         { name: 'drawable-land-xxxhdpi-screen.png', width: 1920,  height: 1280,  density: 'land-xxxhdpi' },
         { name: 'drawable-port-ldpi-screen.png',    width: 240,   height: 320,   density: 'port-ldpi' },
         { name: 'drawable-port-mdpi-screen.png',    width: 320,   height: 480,   density: 'port-mdpi' },
         { name: 'drawable-port-hdpi-screen.png',    width: 480,   height: 800,   density: 'port-hdpi' },
-        { name: 'drawable-port-xhdpi-screen.png',   width: 720,   height: 1280,  density: 'port-xhdpi' },
+        { name: 'drawable-port-xhdpi-screen.png',   width: 640,   height: 960,   density: 'port-xhdpi' },
         { name: 'drawable-port-xxhdpi-screen.png',  width: 960,   height: 1600,  density: 'port-xxhdpi' },
         { name: 'drawable-port-xxxhdpi-screen.png', width: 1280,  height: 1920,  density: 'port-xxxhdpi' }
       ],


### PR DESCRIPTION
The hdpi image was distorted and I checked it out other generator libraries and the proportions was wrong. Look at this for example: http://zeppelindev.com/splash.html#none