### PR TITLE
fix for 302s and cookies being lost

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -347,6 +347,7 @@ Serve.setupProxy = function setupProxy(options, app) {
           opts.agent = false;
 
       opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
+			opts.cookieRewrite = proxy.proxyUrl; //fix for relative url changes (302 redirects)
 
       app.use(proxy.path, proxyMiddleware(opts));
       logging.logger.info('Proxy added:'.green.bold, proxy.path + " => " + url.format(proxy.proxyUrl));


### PR DESCRIPTION
Pull request from the issue below.  I can't take credit for the solution but would like to see this added.

https://github.com/driftyco/ionic-cli/issues/415#event-461419851
