### PR TITLE
Help banner is still shown for removed task

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -508,7 +508,6 @@ Start.fetchGithubStarter = function(options, repoUrl) {
 
   }).catch(function(err) {
     logging.logger.error('Please verify you are using a valid URL or a valid ionic starter.');
-    logging.logger.error('View available starter templates: `ionic templates`');
     logging.logger.error('More info available at: \nhttp://ionicframework.com/getting-started/\nhttps://github.com/driftyco/ionic-cli');
     return Utils.fail('');
   });

--- a/lib/start.js
+++ b/lib/start.js
@@ -508,6 +508,7 @@ Start.fetchGithubStarter = function(options, repoUrl) {
 
   }).catch(function(err) {
     logging.logger.error('Please verify you are using a valid URL or a valid ionic starter.');
+    logging.logger.error('View available starter templates: `ionic start --list`');
     logging.logger.error('More info available at: \nhttp://ionicframework.com/getting-started/\nhttps://github.com/driftyco/ionic-cli');
     return Utils.fail('');
   });


### PR DESCRIPTION
The `templates` task was removed in commit 4f75f8a of ionic-cli repo, but when a starter template is not found, the CLI shows a help message with this task, as shown below:

```
gentlegiant:mobile-workspace trestini$ ionic start timesheet sidebar
Creating Ionic app in folder /Users/trestini/Devel/workspace/mobile-workspace/timesheet based on sidebar project
Downloading: https://github.com/driftyco/ionic-app-base/archive/master.zip
[=============================]  100%  0.0s
Downloading: https://github.com/driftyco/ionic-starter-sidebar/archive/master.zip
 ✗ Not found: https://github.com/driftyco/ionic-starter-sidebar/archive/master.zip (404)
 ✗ Please verify the url and try again.
Please verify you are using a valid URL or a valid ionic starter.
View available starter templates: `ionic templates`
More info available at:
http://ionicframework.com/getting-started/
https://github.com/driftyco/ionic-cli

gentlegiant:mobile-workspace trestini$ ionic templates
  _             _
 (_)           (_)
  _  ___  _ __  _  ___
 | |/ _ \| '_ \| |/ __|
 | | (_) | | | | | (__
 |_|\___/|_| |_|_|\___|  CLI v1.7.14

Usage: ionic task args

=======================

templates is not a valid task

Available tasks: (use --help or -h for more info)
```