### PR TITLE
Add support for windows platform to resources generator

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -135,6 +135,8 @@ var Platforms = {
 		{ name: 'Square44x44Logo.scale-240.png',  width: 106,   height: 106 },
 		{ name: 'Square70x70Logo.scale-100.png',  width: 70,   height: 70 },
 		{ name: 'Square71x71Logo.scale-100.png',  width: 71,   height: 71 },
+		{ name: 'Square71x71Logo.scale-240.png',  width: 170,   height: 170 },
+		{ name: 'Square310x310Logo.scale-100.png',  width: 310,   height: 310 },
 		{ name: 'Square150x150Logo.scale-100.png',  width: 150,   height: 150 },
 		{ name: 'quare150x150Logo.scale-240.png',  width: 360,   height: 360 },
 		{ name: 'Wide310x150Logo.scale-100.png',  width: 310,   height: 150 },

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -26,7 +26,7 @@ var Settings = {
   iconSourceFile: 'icon',
   splashSourceFile: 'splash',
   sourceExtensions: ['psd', 'ai', 'png'],
-  supportedPlatforms: ['android', 'ios', 'wp8'],
+  supportedPlatforms: ['android', 'ios', 'wp8', 'windows'],
   configFile: 'config.xml',
   generateThrottle: 4,
   defaultMaxIconSize: 96,
@@ -125,6 +125,34 @@ var Platforms = {
       nodeName: 'splash',
       nodeAttributes: ['src', 'width', 'height']
     }
+  },
+  
+  windows: {
+    icon: {
+      images: [
+        { name: 'Square30x30Logo.scale-100.png',  width: 30,   height: 30 },
+		{ name: 'Square44x44Logo.scale-100.png',  width: 44,   height: 44 },
+		{ name: 'Square44x44Logo.scale-240.png',  width: 106,   height: 106 },
+		{ name: 'Square70x70Logo.scale-100.png',  width: 70,   height: 70 },
+		{ name: 'Square71x71Logo.scale-100.png',  width: 71,   height: 71 },
+		{ name: 'Square150x150Logo.scale-100.png',  width: 150,   height: 150 },
+		{ name: 'quare150x150Logo.scale-240.png',  width: 360,   height: 360 },
+		{ name: 'Wide310x150Logo.scale-100.png',  width: 310,   height: 150 },
+        { name: 'Wide310x150Logo.scale-240.png',  width: 744,   height: 360 },
+		{ name: 'StoreLogo.scale-100.png',  width: 50,   height: 50 },
+		{ name: 'StoreLogo.scale-240.png',  width: 120,   height: 120 }
+      ],
+      nodeName: 'icon',
+      nodeAttributes: ['src', 'width', 'height']
+    },
+    splash: {
+      images: [
+        { name: 'SplashScreen.scale-100.png',  width: 620,   height: 300 },
+		{ name: 'SplashScreenPhone.scale-240.png',  width: 1152,   height: 1920 },
+      ],
+      nodeName: 'splash',
+      nodeAttributes: ['src', 'width', 'height']
+    }
   }
 
 };
@@ -174,6 +202,8 @@ function generate(dir, options) {
     buildPlatforms.push('android');
   } else if (_.contains(options.platforms, 'wp8')) {
     buildPlatforms.push('wp8');
+  } else if (_.contains(options.platforms, 'windows')) {
+    buildPlatforms.push('windows');
   } else if (!fs.existsSync(path.join(appDirectory, 'platforms'))) {
     hasPlatforms = false;
   } else {


### PR DESCRIPTION
This patch modifies resources.js so that the 'iconic resources'  command will generated splash screens and icons for a "windows" platform project, supporting Windows 8, Windows 8.1, Windows 10.

All images that are copied by "cordova prepare" are created. This is a subset of the full list of images that can being configured in the windows app manifest files.