### PR TITLE
fix(start): use adm-zip instead of unzip2

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -8,7 +8,6 @@ var fs = require('fs'),
     colors = require('colors'),
     Q = require('q'),
     open = require('open'),
-    unzip = require('unzip2'),
     xml2js = require('xml2js'),
     ProgressBar = require('progress'),
     IonicProject = require('./project'),
@@ -293,6 +292,8 @@ Start.fetchCreatorApp = function(options) {
   }
 
   function _fetchCreatorApp() {
+    var AdmZip = require('adm-zip');
+
     // var self = this;
     var appId = options.template.split(':')[1];
     //var downloadUrl = IONIC_DASH + path.join('/api/v1/creator', appId, 'download/html');
@@ -314,22 +315,9 @@ Start.fetchCreatorApp = function(options) {
 
         try {
           fs.writeFileSync(tempZipFilePath, body);
-
-          var readStream = fs.createReadStream(tempZipFilePath);
-          readStream.on('error', function(err) {
-            log.debug('unzipRepo readStream error: ' + err);
-            q.reject(err);
-          });
-
-          var writeStream = unzip.Extract({ path: wwwPath });
-          writeStream.on('close', function() {
-            q.resolve();
-          });
-          writeStream.on('error', function(err) {
-            log.debug('unzipRepo writeStream: ' + err);
-            q.reject(err);
-          });
-          readStream.pipe(writeStream);
+          var zip = new AdmZip(tempZipFilePath);
+          zip.extractAllTo(wwwPath);
+          q.resolve();
         } catch(e) {
           log.error(e);
           q.reject(e);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -86,7 +86,7 @@ Utils.fetchArchive = function fetchArchive(targetPath, archiveUrl, isGui) {
   var os = require('os');
   var fs = require('fs');
   var path = require('path');
-  var unzip = require('unzip2');
+  var AdmZip = require('adm-zip');
   var q = Q.defer();
 
   // The folder name the project will be downloaded and extracted to
@@ -95,25 +95,6 @@ Utils.fetchArchive = function fetchArchive(targetPath, archiveUrl, isGui) {
 
   var tmpFolder = os.tmpdir();
   var tempZipFilePath = path.join(tmpFolder, 'ionic-starter-' + new Date().getTime() + '.zip');
-
-
-  var unzipRepo = function unzipRepo(fileName) {
-    var readStream = fs.createReadStream(fileName);
-    readStream.on('error', function(err) {
-      log.debug('unzipRepo readStream error: ' + err);
-      q.reject(err);
-    });
-
-    var writeStream = unzip.Extract({ path: targetPath });
-    writeStream.on('close', function() {
-      q.resolve();
-    });
-    writeStream.on('error', function(err) {
-      log.debug('unzipRepo writeStream error: ' + err);
-      q.reject(err);
-    });
-    readStream.pipe(writeStream);
-  };
 
   var proxy = process.env.PROXY || process.env.http_proxy || null;
   var request = require('request');
@@ -140,7 +121,9 @@ Utils.fetchArchive = function fetchArchive(targetPath, archiveUrl, isGui) {
     }
     try {
       fs.writeFileSync(tempZipFilePath, body);
-      unzipRepo(tempZipFilePath);
+      var zip = new AdmZip(tempZipFilePath);
+      zip.extractAllTo(targetPath);
+      q.resolve();
     } catch(e) {
       log.debug('fetchArchive request write: ', e);
       q.reject(e);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "adm-zip": "0.4.7",
     "archiver": "0.5.2",
     "cheerio": "0.19.0",
     "colors": "0.6.2",
@@ -64,7 +65,6 @@
     "shelljs": "0.2.6",
     "tiny-lr-fork": "0.0.5",
     "underscore": "1.7.0",
-    "unzip2": "0.2.5",
     "winston": "1.1.2",
     "xml2js": "0.4.16"
   },


### PR DESCRIPTION
Addresses https://github.com/driftyco/ionic-cli/issues/908. There is a
bug in the unzip2 library that causes unzipping to break when it
encounters an empty file:
https://github.com/glebdmitriew/node-unzip-2/issues/2.