### PR TITLE
Check if option runLivereload is set before calling .cyan on undefined string

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -489,7 +489,9 @@ Serve.start = function start(options) {
       return Serve.runLivereload(options, app);
     })
     .then(function(data) {
-      log.info('Running live reload server:', options.liveReloadServer.cyan);
+      if (options.runLivereload) {
+        log.info('Running live reload server:', options.liveReloadServer.cyan);
+      }
       log.info('Watching:', options.watchPatterns.join(', ').cyan);
       return Serve.startServer(options, app);
     })


### PR DESCRIPTION
Fixes #90 