### PR TITLE
Add missing jshint/istanbul dependencies.

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -489,7 +489,9 @@ Serve.start = function start(options) {
       return Serve.runLivereload(options, app);
     })
     .then(function(data) {
-      log.info('Running live reload server:', options.liveReloadServer.cyan);
+      if (options.runLivereload) {
+        log.info('Running live reload server:', options.liveReloadServer.cyan);
+      }
       log.info('Watching:', options.watchPatterns.join(', ').cyan);
       return Serve.startServer(options, app);
     })

--- a/package.json
+++ b/package.json
@@ -69,13 +69,15 @@
     "xml2js": "0.4.16"
   },
   "devDependencies": {
+    "istanbul": "^0.4.3",
     "jasmine-node": "1.14.5",
+    "jshint": "^2.9.1",
     "rewire": "2.5.1"
   },
   "scripts": {
     "test": "npm run jasmine",
-    "jshint": "node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint spec",
-    "jasmine": "jasmine-node --captureExceptions  ./spec",
-    "cover": "node node_modules/istanbul/lib/cli.js cover --root src --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
+    "jshint": "node_modules/.bin/jshint lib spec --exclude lib/assets",
+    "jasmine": "node_modules/.bin/jasmine-node --captureExceptions  ./spec",
+    "cover": "node node_modules/istanbul/lib/cli.js cover --root lib --print detail node_modules/jasmine-node/bin/jasmine-node -- spec-cordova spec-plugman"
   }
 }


### PR DESCRIPTION
Fixes #92  
When running the tests/jshint npm scripts I encountered some issues so I refactored the scripts section within package.json. 

Not sure why we are calling out node directly as the libraries `jshint/jasmine-node` both have the appropriate shebang reference unless I am missing something here?