### PR TITLE
Fix for 'package download' failing with proxy

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -137,7 +137,12 @@ Package.downloadBuild = function(appId, jar, buildId, downloadDir) {
       filename = build.name + '.' + Package.determineFileExtensionByPlatform(build.platform);
       filepath = path.join(downloadDir, filename);
 
-      requestProgess(request({ url: build.url }))
+      var reqParams = {
+        url: build.url,
+        proxy: process.env.PROXY || process.env.http_proxy || null
+      }
+
+      requestProgess(request(reqParams))
         .on('progress', function(state) {
           q.notify(state);
         })


### PR DESCRIPTION
The call to requestProgess which handles the actual file download is missing the proxy parameter that allows it to work from behind proxies. This PR adds the parameter. It has been tested in my proxy environment and resolves the problem.

Error received before fix:
16:12:47 + ionic package download 5
16:12:49 
16:12:49 Error: tunneling socket could not be established, cause=write EPROTO 140355477145408:error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol:../deps/openssl/openssl/ssl/s23_clnt.c:794:
16:12:49 
16:12:49     at ClientRequest.onError (/var/lib/jenkins/.nvm/versions/node/v4.4.3/lib/node_modules/ionic/node_modules/tunnel-agent/index.js:176:17)
16:12:49     at ClientRequest.g (events.js:260:16)
16:12:49     at emitOne (events.js:77:13)
16:12:49     at ClientRequest.emit (events.js:169:7)
16:12:49     at TLSSocket.socketErrorListener (_http_client.js:256:9)
16:12:49     at emitOne (events.js:77:13)
16:12:49     at TLSSocket.emit (events.js:169:7)
16:12:49     at onwriteError (_stream_writable.js:313:10)
16:12:49     at onwrite (_stream_writable.js:331:5)
16:12:49     at WritableState.onwrite (_stream_writable.js:89:5)
16:12:49 
16:12:49 tunneling socket could not be established, cause=write EPROTO 140355477145408:error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol:../deps/openssl/openssl/ssl/s23_clnt.c:794:
16:12:49  (CLI v1.7.14)