### PR TITLE
Fix#103 prevent lab throwing errors

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -223,7 +223,7 @@ Serve.openBrowser = function openBrowser(options) {
     }
 
     if (options.platform) {
-      openUrl.push('?ionicplatform=', options.platform);
+      openUrl.push('?ionicPlatform=', options.platform);
     }
 
     try {


### PR DESCRIPTION
changing variable name **ionicplatform** to **ionicPlatform**
