### PR TITLE
Problem calling Serve.stopServer after Serve.start for automated tests - #113

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -490,14 +490,18 @@ Serve.startServer = function startServer(options, app) {
 
 
   // Listen
+  var q = Q.defer();
   app.use(server);
   try {
-    runningServer = app.listen(options.port, options.address);
+    runningServer = app.listen(options.port, options.address,function(){
+        logging.logger.info('Running dev server: '.green.bold, options.devServer);
+        q.resolve()
+    });
   }catch(ex) {
-    Utils.fail('Failed to start the Ionic server: ', ex.message);
+    q.reject(Utils.fail('Failed to start the Ionic server: ', ex.message));
   }
 
-  logging.logger.info('Running dev server: '.green.bold, options.devServer);
+  return q.promise;
 };
 
 Serve.start = function start(options) {
@@ -990,11 +994,17 @@ Serve.host = function host(address, port) {
 
 
 Serve.stopServer = function stopServer() {
-  if (runningServer) {
-    runningServer.close();
-    lrServer.close();
-    logging.logger.info('Server closed');
-  } else {
+  if(!runningServer && !lrServer){
     logging.logger.info('Server not running');
+    return;
   }
+
+  if(runningServer){
+    runningServer.close();
+  }
+  if(lrServer){
+    lrServer.close();
+  }
+
+  logging.logger.info('Server closed');
 }


### PR DESCRIPTION
Changes made on Serve.startServer, allowing to wait for server to really start.

Solving issue https://github.com/driftyco/ionic-app-lib/issues/113