### PR TITLE
update dependency glob-watcher to 3.0.0 fixing high cpu in docker

### DIFF
--- a/lib/serve.js
+++ b/lib/serve.js
@@ -277,10 +277,10 @@ Serve.runLivereload = function runLivereload(options, app) {
     // log.debug('Absolute watch paths:', absoluteWatchPaths);
 
     var watcher = globWatch(options.watchPatterns);
-    watcher.on('change', function(evt) {
+    watcher.on('change', function(path) {
 
       // TODO: Move prototype to Serve._changed
-      Serve._changed(evt.path, options);
+      Serve._changed(path, options);
     });
 
     var liveReloadPort = process.env.CONNECT_LIVE_RELOAD_PORT || options.liveReloadPort;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cross-spawn-async": "2.1.9",
     "finalhandler": "0.2.0",
     "form-data": "0.1.4",
-    "glob-watcher": "2.0.0",
+    "glob-watcher": "3.0.0",
     "open": "0.0.5",
     "optimist": "0.6.0",
     "progress": "1.1.7",


### PR DESCRIPTION
Running ionic serve with live reload from a docker image (probably in other scenario's as well) causes a 300% cpu load. The latest glob-watcher dependency replaced their means for watching file system changes (from gaze to chokidar) resolving this issue.
