### PR TITLE
Remove the .bold calls

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -147,8 +147,8 @@ Upload.signalDashUpload = function signalDashUpload(project, jar) {
     if (error || parseInt(response.statusCode, 10) !== 200) {
       q.reject('Upload Failed:', error || 'Server Error: ' + response.statusCode);
     } else {
-      log.info(('Successfully uploaded (' + project.get('app_id') + ')\n').bold);
-      log.info(('Share your beautiful app with someone:\n\n$ ionic share EMAIL\n').bold);
+      log.info(('Successfully uploaded (' + project.get('app_id') + ')\n'));
+      log.info(('Share your beautiful app with someone:\n\n$ ionic share EMAIL\n'));
       q.resolve(JSON.parse(body));
     }
   });
@@ -199,7 +199,7 @@ Upload.deploy = function deploy(project, jar, deploy) {
   log.debug('Check for a deploy...');
 
   if (deploy) {
-    log.info('Deploying to channel: ' + deploy.channel.label.green.bold);
+    log.info('Deploying to channel: ' + deploy.channel.label.green);
 
     var proxy = process.env.PROXY || process.env.HTTP_PROXY || null;
 
@@ -223,7 +223,7 @@ Upload.deploy = function deploy(project, jar, deploy) {
       if (error || parseInt(response.statusCode, 10) !== 200) {
         q.reject('Deploy failed: ' +  (error || response.statusCode));
       } else {
-        log.info('Deploy Successful!'.green.bold);
+        log.info('Deploy Successful!'.green);
         q.resolve(true);
       }
     });


### PR DESCRIPTION
Scenario
Using `ionic package build android` fails due to .bold being called on a string.

The issue below for colors.js lib helps to explain.
https://github.com/Marak/colors.js/issues/110

Related issue on ionic-cli
https://github.com/driftyco/ionic-cli/issues/1344

I propose that we simply remove the calls .bold in the interim so that users of the ionic framework cli can at least use the `ionic package build $PLATFORM` command.
