### PR TITLE
Get the proxy from a single function inside Utils instead of repeating code everywhere

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -122,7 +122,7 @@ Login.requestLogIn = function requestLogin(email, password, saveCookies) {
       username: email.toString(),
       password: password
     },
-    proxy: process.env.PROXY || process.env.http_proxy || null
+    proxy: Utils.getProxy()
   }, function(err, response) {
     if (err) {
       return q.reject('Error logging in: ' + err);
@@ -193,7 +193,7 @@ Login.getUserInfo = function getUserInfo(jar) {
         return c.key + '=' + encodeURIComponent(c.value);
       }).join('; ')
     },
-    proxy: process.env.PROXY || process.env.http_proxy || null
+    proxy: Utils.getProxy()
   }, function(err, response, body) {
     if (err) {
       return q.reject('Error logging in: ' + err);
@@ -228,7 +228,7 @@ Login.getUserApps = function getUserApps(jar) {
         return c.key + '=' + encodeURIComponent(c.value);
       }).join('; ')
     },
-    proxy: process.env.PROXY || process.env.http_proxy || null
+    proxy: Utils.getProxy()
   }, function(err, response, body) {
     if (err) {
       return q.reject('Error logging in: ' + err);
@@ -261,7 +261,7 @@ Login.getDownloadLink = function getDownloadLink(jar, appId) {
         return c.key + '=' + encodeURIComponent(c.value);
       }).join('; ')
     },
-    proxy: process.env.PROXY || process.env.http_proxy || null
+    proxy: Utils.getProxy()
   }, function(err, response, body) {
     if (err) {
       return q.reject('Error logging in: ' + err);

--- a/lib/package.js
+++ b/lib/package.js
@@ -61,7 +61,7 @@ Package.listBuilds = function(appId, jar) {
     url: settings.IONIC_DASH_API + 'apps/' + appId + '/package/builds/',
     qs: { app_id: appId }, // eslint-disable-line camelcase
     useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);
@@ -94,7 +94,7 @@ Package.getBuild = function(appId, jar, buildId, extraQueryParams) {
     url: settings.IONIC_DASH_API + 'apps/' + appId + '/package/builds/' + buildId,
     qs: _.extend({ app_id: appId }, extraQueryParams), // eslint-disable-line camelcase
     useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);
@@ -325,7 +325,7 @@ function sendProjectZip(appId, jar) {
     url: settings.IONIC_DASH_API + 'apps/' + appId + '/package/projects/',
     qs: { app_id: appId }, // eslint-disable-line camelcase
     useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);
@@ -360,7 +360,7 @@ function uploadProjectZip(url, formData, projectZipPath) {
   request.post({
     url: url,
     formData: formData,
-    proxy: process.env.PROXY || process.env.http_proxy || null
+    proxy: Utils.getProxy()
   }, function(err, response, body) {
     if (err) {
       log.error('Error:', err);
@@ -386,7 +386,7 @@ function sendToPackageService(appId, jar, formData) {
     qs: { app_id: appId }, // eslint-disable-line camelcase
     useQuerystring: true,
     formData: formData,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -447,7 +447,7 @@ function loadSourceImages() {
         image_id: sourceFile.imageId, // eslint-disable-line camelcase
         src: fs.createReadStream(sourceFile.filePath)
       },
-      proxy: process.env.PROXY || null
+      proxy: Utils.getProxy()
     };
 
     request.post(postData, function(err, httpResponse, body) {
@@ -606,7 +606,7 @@ function generateResourceImage(image) {
         crop: 'center',
         encoding: 'png'
       },
-      proxy: process.env.PROXY || null
+      proxy: Utils.getProxy()
     };
 
     var wr = fs.createWriteStream(image.tmpPath, { flags: 'w' });

--- a/lib/security.js
+++ b/lib/security.js
@@ -14,7 +14,7 @@ Security.addProfile = function(appId, jar, name) {
 
     // qs: {"app_id": appId},
     // useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     formData: {
       name: name,
       tag: name.toLowerCase().replace(/\s/g, '_').replace(/[^a-z_]/g, '')
@@ -55,7 +55,7 @@ Security.listProfiles = function(appId, jar) {
 
     // qs: {"app_id": appId},
     // useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);
@@ -88,7 +88,7 @@ Security.getProfile = function(appId, jar, tag) {
 
     // qs: {"app_id": appId},
     // useQuerystring: true,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);
@@ -147,7 +147,7 @@ function sendCredentials(appId, jar, profileTag, formData) {
     // qs: {"app_id": appId},
     // useQuerystring: true,
     formData: formData,
-    proxy: process.env.PROXY || process.env.http_proxy || null,
+    proxy: Utils.getProxy(),
     headers: {
       cookie: jar.map(function(c) {
         return c.key + '=' + encodeURIComponent(c.value);

--- a/lib/start.js
+++ b/lib/start.js
@@ -306,7 +306,7 @@ Start.fetchCreatorApp = function(options) {
 
     var q = Q.defer();
 
-    var proxy = process.env.PROXY || null;
+    var proxy = Utils.getProxy();
 
     request({ url: downloadUrl, proxy: proxy, encoding: null }, function(err, res, body) {
       if (!err && res && parseInt(res.statusCode, 10) === 200) {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -94,7 +94,7 @@ Upload.uploadToS3 = function uploadToS3(appDirectory, keyInfo) {
 
   log.debug('Uploading zip file to S3');
 
-  var proxy = process.env.PROXY || process.env.HTTP_PROXY || null;
+  var proxy = Utils.getProxy();
   var zipFile = path.join(appDirectory, TEMP_FILENAME);
 
   // Now we upload with the signed URL the dash returned
@@ -130,7 +130,7 @@ Upload.signalDashUpload = function signalDashUpload(project, jar) {
 
   log.debug('Signaling to ionic.io completion of the upload');
 
-  var proxy = process.env.PROXY || process.env.HTTP_PROXY || null;
+  var proxy = Utils.getProxy();
 
   // The final step is to signal the dash that the file was successfully uploaded
   request({
@@ -163,7 +163,7 @@ Upload.verify_tag = function verify_tag(project, jar, deploy, version) { // esli
 
   if (deploy && version) {
 
-    var proxy = process.env.PROXY || process.env.HTTP_PROXY || null;
+    var proxy = Utils.getProxy();
 
     request({
       method: 'GET',
@@ -201,7 +201,7 @@ Upload.deploy = function deploy(project, jar, deploy) {
   if (deploy) {
     log.info('Deploying to channel: ' + deploy.channel.label.green.bold);
 
-    var proxy = process.env.PROXY || process.env.HTTP_PROXY || null;
+    var proxy = Utils.getProxy();
 
     var csrftoken = Utils.retrieveCsrfToken(jar);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,17 @@ Utils.retrieveCsrfToken = function retrieveCsrfToken(jar) {
 };
 
 /**
+ * Utils.getProxy will return a string that represents a HTTP proxy server
+ * setup by the user in their environment variables.
+ *
+ * No parameters are required
+ * @return {String} or null if no proxy has been setup
+ */
+Utils.getProxy = function() {
+  return process.env.PROXY || process.env.HTTP_PROXY || process.env.http_proxy || process.env.proxy || null;
+}
+
+/**
  * Utils.createArchive will zip up a subdirectory in the app directory
  *
  * Utils.createArchive(appDirectory, 'www') makes a zip file at
@@ -97,7 +108,7 @@ Utils.fetchArchive = function fetchArchive(targetPath, archiveUrl, isGui) {
   var tmpFolder = os.tmpdir();
   var tempZipFilePath = path.join(tmpFolder, 'ionic-starter-' + new Date().getTime() + '.zip');
 
-  var proxy = process.env.PROXY || process.env.http_proxy || null;
+  var proxy = Utils.getProxy();
   var request = require('request');
   request({ url: archiveUrl, rejectUnauthorized: false, encoding: null, proxy: proxy }, function(err, res, body) {
     if (err) {

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -19,7 +19,7 @@ describe('Utils', function() {
 
   it('should have methods defined', function() {
     var methods = ['transformCookies', 'retrieveCsrfToken', 'createArchive', 'fetchArchive',
-      'preprocessOptions', 'getContentSrc', 'fail'];
+      'preprocessOptions', 'getContentSrc', 'fail', 'getProxy'];
     methods.forEach(function(method) {
       expect(Utils[method]).toBeDefined();
     });
@@ -30,6 +30,12 @@ describe('Utils', function() {
       expect(function() {
         Utils.transformCookies(null);
       }).toThrow('You parse out cookies if they are null');
+    });
+  });
+
+  describe('#getProxy', function() {
+    it('should return null proxy if nothing is there in the env variable', function() {
+      expect(Utils.getProxy()).toEqual(null);
     });
   });
 


### PR DESCRIPTION
- Added a single test for `Utils.getProxy`
- Please tell me how to spoof the environment variable from inside the spec, so that I can write the other test where the function returns a valid proxy

Fixes #122 