### PR TITLE
Fix start command to properly process v2 local directory template

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -469,10 +469,19 @@ Start.fetchLocalStarter = function(options) {
       return q.promise;
     }
 
-    log.info('\nCopying files to www from:'.bold, localStarterPath);
+    // for v2, copy both 'src' and 'www' folder to target path
+    if (options.v2) {
+        log.info('\nCopying files to project from:'.bold, localStarterPath);
 
-    // Move the content of this repo into the www folder
-    shelljs.cp('-Rf', path.join(localStarterPath, '*'), path.join(options.targetPath, 'www'));
+        shelljs.cp('-Rf', path.join(localStarterPath, '*'), options.targetPath);
+    }
+    // for v1, only focus on 'www' folder
+    else {
+      log.info('\nCopying files to www folder from:'.bold, localStarterPath);
+
+      // Move the content of this repo into the www folder
+      shelljs.cp('-Rf', path.join(localStarterPath, '*'), path.join(options.targetPath, 'www'));
+    }
 
     q.resolve();
   } catch (e) {


### PR DESCRIPTION
In v2, `src` folder should not be copied into destination `www` folder
of generated project. This changes fixed it.