### PR TITLE
Remove deprecated module `sys`

### DIFF
--- a/lib/hooks/after_platform_add/010_install_plugins.js
+++ b/lib/hooks/after_platform_add/010_install_plugins.js
@@ -5,7 +5,6 @@
  * https://raw.githubusercontent.com/diegonetto/generator-ionic/master/templates/hooks/after_platform_add/install_plugins.js
  */
 var exec = require('child_process').exec;
-var sys = require('sys');
 
 var packageJSON = null;
 
@@ -20,6 +19,6 @@ try {
 packageJSON.cordovaPlugins = packageJSON.cordovaPlugins || [];
 packageJSON.cordovaPlugins.forEach(function(plugin) {
   exec('cordova plugin add ' + plugin, function(error, stdout) {
-    sys.puts(stdout);
+    console.log(stdout);
   });
 });


### PR DESCRIPTION
Remove reference to deprecated module `sys`, and replace only call
to `sys.puts` with `console.log`.