### PR TITLE
feat(start): Yarn option to install dependencies

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -99,7 +99,11 @@ Start.startApp = function startApp(options) {
     return Start.fetchSeed(options);
   })
   .then(function() {
-    if (!options.skipNpm) {
+    if (options.yarn) {
+      log.info('Installing npm packages via Yarn (may take a minute or two)...');
+      return Start.runSpawnCommand('yarn', ['install']);
+    }
+    else if (!options.skipNpm) {
       log.info('Installing npm packages (may take a minute or two)...');
       return Start.runSpawnCommand('npm', ['install']);
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,6 +196,7 @@ Utils.preprocessCliOptions = function preprocessCliOptions(argv) {
     options.typescript = argv.typescript || argv.ts;
     options.v2 = argv.v2 || argv.v;
     options.skipNpm = argv['skip-npm'];
+    options.yarn = argv.yarn;
 
     // internal commands for changing which branches the starter should use
     options.wrapperBranchName = argv.wrapperBranchName;


### PR DESCRIPTION
Add an option to install Node dependencies via yarn instead of npm.

Goes hand-in-hand with driftyco/ionic-cli#1804