### PR TITLE
Patch 1

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -299,7 +299,9 @@ Upload.getDirectUploadKey = function getDirectUploadKey(project, jar, note) {
         return q.reject('Session expired (401). Please log in and run this command again.');
       } else if (parseInt(response.statusCode, 10) === 403) {
         return q.reject('Forbidden upload (403)');
-      } else if (parseInt(response.statusCode, 10) === 500) {
+      } else if (parseInt(response.statusCode, 10) === 404) {
+        return q.reject('App ID not found (404)');
+      }else if (parseInt(response.statusCode, 10) === 500) {
         return q.reject('Server Error (500) :(');
       } else if (parseInt(response.statusCode, 10) === 522) {
         return q.reject('Connection timed out (522) :(');

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -301,7 +301,7 @@ Upload.getDirectUploadKey = function getDirectUploadKey(project, jar, note) {
         return q.reject('Forbidden upload (403)');
       } else if (parseInt(response.statusCode, 10) === 404) {
         return q.reject('App ID not found (404)');
-      }else if (parseInt(response.statusCode, 10) === 500) {
+      } else if (parseInt(response.statusCode, 10) === 500) {
         return q.reject('Server Error (500) :(');
       } else if (parseInt(response.statusCode, 10) === 522) {
         return q.reject('Connection timed out (522) :(');


### PR DESCRIPTION
Currently if a 404 is returned you get a json parsing error as seen in driftyco/ionic-cli#1765 which is entirely unhelpful and pretty confusing. This change will show that a 404 was received and give relevant information to whoever gets the error.

Something should probably be done to generally handle any case where the API will return HTML instead of JSON, but this will help alleviate some confusion in the mean time.