### PR TITLE
Fix upload.js, error uploading application due to invalid parameter.

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -238,6 +238,11 @@ Upload.deploy = function deploy(project, jar, deploy) {
 Upload.getDirectUploadKey = function getDirectUploadKey(project, jar, note) {
   var q = Q.defer();
 
+  if (!jar) {
+    q.reject('There was an error trying to load your app. :(');
+    return q.promise;
+  }
+
   note = note ? note : '';
 
   log.debug('Getting Upload information from ', settings.IONIC_DASH);


### PR DESCRIPTION
**When the jar parameter is undefined then an error occurs:**
```sh
Uploading app...

An error occurred uploading the build:
TypeError: Cannot read property 'map' of undefined
TypeError: Cannot read property 'map' of undefined
    at Object.getDirectUploadKey (/usr/lib/node_modules/ionic/node_modules/ionic-app-lib/lib/upload.js:272:18)
....
```

**After fixing it looks like this:**
```sh
Uploading app...

There was an error trying to load your app. :(
```

* The error is exactly the following code snippet:
```js
       //==> var 'jar' is undefined
      cookie: jar.map(function(c) {
        return c.key + '=' + encodeURIComponent(c.value);
      }).join('; ')
```