### PR TITLE
Add regex to parse cordova version to account for telemetry warning

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -146,7 +146,7 @@ Info.gatherInfo = function gatherInfo() {
       return result.value;
     });
     allEnvironmentInfo = {
-      cordova: results[0],
+      cordova: /(?:\d+?\.){2}\d+/g.exec(results[0])[0]),
       xcode: results[1],
       ios_deploy: results[2], // eslint-disable-line camelcase
       ios_sim: results[3], // eslint-disable-line camelcase


### PR DESCRIPTION
Would fix issue [drifty/ionic-cli#1376](https://github.com/driftyco/ionic-cli/issues/1376)

Might be a good idea to add tests if all of `allEnvironmentInfo`'s data should be semantic version numbers; `semver.valid` could be used.